### PR TITLE
feat(claude-code): add comfy-cloud plugin (MCP + slash commands)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "comfy-skills",
+  "description": "Comfy skills and plugins for AI coding agents. Includes comfy-cloud, the Comfy Cloud MCP connection plus slash commands for Claude Code.",
+  "owner": {
+    "name": "Comfy Org",
+    "url": "https://comfy.org"
+  },
+  "plugins": [
+    {
+      "name": "comfy-cloud",
+      "source": "./claude-code",
+      "description": "Comfy Cloud in Claude Code: the hosted MCP connection plus slash commands for generating images, video, audio, and 3D and searching the catalog.",
+      "homepage": "https://docs.comfy.org/cloud/mcp"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,50 +1,62 @@
 # Comfy Skills
 
-The single source of truth for **Comfy Cloud product skills** -- the slash commands that let an AI agent generate images, video, audio, and 3D, search models and nodes, and run ComfyUI workflows through [Comfy Cloud](https://cloud.comfy.org).
+Home of **Comfy Cloud skills and plugins for AI coding agents** — the slash commands and MCP connection that let an agent generate images, video, audio, and 3D, search models and nodes, and run ComfyUI workflows through [Comfy Cloud](https://cloud.comfy.org).
 
-These are end-user skills (for people using Comfy Cloud via Claude Code, Claude Desktop, and other MCP clients). For internal Comfy engineering conventions, see [comfy-conventions](https://github.com/Comfy-Org/comfy-conventions) instead.
+For internal Comfy engineering conventions, see [comfy-conventions](https://github.com/Comfy-Org/comfy-conventions) instead.
 
-## Skills
+## Install (Claude Code)
 
-| Skill | What it does |
+The **`comfy-cloud`** plugin bundles the Comfy Cloud MCP connection **and** the slash commands in one step:
+
+```
+/plugin marketplace add Comfy-Org/comfy-skills
+/plugin install comfy-cloud@comfy-skills
+```
+
+Then run `/mcp` to sign in (OAuth). That's it — the plugin registers the hosted MCP server (`https://cloud.comfy.org/mcp`) and adds the commands.
+
+Commands are namespaced under the plugin, e.g. `/comfy-cloud:generate-image`, `/comfy-cloud:search-models`, `/comfy-cloud:help`.
+
+> **Other clients** (Claude Desktop, etc.) don't use Claude Code plugins — they connect to the same hosted MCP server through their own config. Full per-client setup lives in the docs: **https://docs.comfy.org/cloud/mcp**
+
+## Commands
+
+| Command | What it does |
 |---|---|
-| `comfy-generate-image` | Generate, edit, or modify an image |
-| `comfy-generate-video` | Generate, edit, or extend a video |
-| `comfy-generate-audio` | Generate audio |
-| `comfy-generate-3d` | Generate a 3D model |
-| `comfy-remove-background` | Remove the background from an image |
-| `comfy-upscale-image` | Upscale an image |
-| `comfy-search-models` | Search available models |
-| `comfy-search-nodes` | Search available nodes |
-| `comfy-search-templates` | Search workflow templates |
-| `comfy-help` | Show what the Comfy Cloud tools can do |
-| `technique-combine-people` | Composite a user's photo with another person |
-| `comfy-rickroll` | Exactly what it sounds like |
+| `/comfy-cloud:generate-image` | Generate, edit, or modify an image |
+| `/comfy-cloud:generate-video` | Generate, edit, or extend a video |
+| `/comfy-cloud:generate-audio` | Generate audio |
+| `/comfy-cloud:generate-3d` | Generate a 3D model |
+| `/comfy-cloud:remove-background` | Remove the background from an image |
+| `/comfy-cloud:upscale-image` | Upscale an image |
+| `/comfy-cloud:search-models` | Search available models |
+| `/comfy-cloud:search-nodes` | Search available nodes |
+| `/comfy-cloud:search-templates` | Search workflow templates |
+| `/comfy-cloud:help` | Show what the Comfy Cloud tools can do |
+| `/comfy-cloud:combine-people` | Composite a user's photo with another person |
+| `/comfy-cloud:rickroll` | Exactly what it sounds like |
 
-## How these are used
+## Repo layout
 
-This repo is the **one place** the skills are authored. Everything else consumes from here, so the guidance never drifts across surfaces:
-
-- **Installers** (the Comfy Cloud MCP installer) pull these skill files and install them as local slash commands on the user's machine.
-- **The MCP server** bundles them at build time so the same guidance is available as server-side prompts.
-
-One source, many delivery surfaces. Do not hand-edit copies elsewhere -- change them here.
+- **`claude-code/`** — the `comfy-cloud` Claude Code plugin: `commands/` (the slash commands) plus `.claude-plugin/plugin.json` (metadata + the bundled MCP server). **Edit commands here.**
+- **`.claude-plugin/marketplace.json`** — the marketplace manifest so `/plugin marketplace add Comfy-Org/comfy-skills` resolves the plugin.
+- **`skills/`** — *legacy* flat command files for the deprecated `comfy-cloud-mcp` curl installer. Frozen; will be removed once that installer fully retires.
 
 ## Authoring rule: steer the approach, defer the specifics
 
-A skill installed on a user's machine is **frozen at install time**. So a skill must never hard-code facts that change -- which templates exist, which model names are live, which nodes are available. Those rot, and a user who installed in spring is then following guidance written in winter.
+A command installed on a user's machine is **frozen at install time**. So it must never hard-code facts that change -- which templates exist, which model names are live, which nodes are available. Those rot, and a user who installed in spring is then following guidance written in winter.
 
-Write skills in two layers:
+Write commands in two layers:
 
 1. **Stable steering** (safe to freeze): the approach. For example, "look for a template first, clone it, swap the input, then submit; prefer structured discovery over guessing."
-2. **Live specifics** (never freeze): tell the agent to *discover* current options at run time via the tools, rather than listing them inline. For example, use `search_templates` with the `tag` filter, or `search_nodes` with its typed `output_type` / `category` params, instead of pasting today's template names or node lists into the skill.
+2. **Live specifics** (never freeze): tell the agent to *discover* current options at run time via the tools, rather than listing them inline. For example, use `search_templates` with the `tag` filter, or `search_nodes` with its typed `output_type` / `category` params, instead of pasting today's template names or node lists into the command.
 
-If you find yourself writing a literal model name, template name, or node id into a skill, stop and point the agent at the tool that returns the current set instead. That keeps the skill correct as the catalog moves, and it keeps the agent from going off on a tangent before it engages the right tool.
+If you find yourself writing a literal model name, template name, or node id into a command, stop and point the agent at the tool that returns the current set instead. That keeps the command correct as the catalog moves, and it keeps the agent from going off on a tangent before it engages the right tool.
 
 ## Contributing
 
-Skills are plain markdown. Add or edit a file under `skills/`, keep it thin per the rule above, and open a PR. Keep prose clear and free of emoji.
+Commands are plain markdown with a short YAML frontmatter `description`. Add or edit a file under `claude-code/commands/`, keep it thin per the rule above, and open a PR. Run `claude plugin validate ./claude-code` before pushing. Keep prose clear and free of emoji.
 
 ## Status
 
-Being consolidated as the canonical home for Comfy Cloud product skills (previously duplicated across the MCP server and installer repos). Consumer wiring (installer pull + server build-time bundling) is in progress.
+`comfy-cloud` is the canonical Claude Code plugin (MCP + commands). The legacy `skills/` flat layout remains only for the deprecated `comfy-cloud-mcp` installer and will be removed once that retires. Cursor / Codex support can be added later as sibling folders.

--- a/claude-code/.claude-plugin/plugin.json
+++ b/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "comfy-cloud",
+  "description": "Comfy Cloud for Claude Code — generate images, video, audio, and 3D, search models, nodes, and templates, and run ComfyUI workflows. Bundles the hosted Comfy Cloud MCP connection plus slash commands.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Comfy Org",
+    "url": "https://comfy.org"
+  },
+  "homepage": "https://docs.comfy.org/cloud/mcp",
+  "mcpServers": {
+    "comfy-cloud": {
+      "type": "http",
+      "url": "https://cloud.comfy.org/mcp"
+    }
+  }
+}

--- a/claude-code/commands/combine-people.md
+++ b/claude-code/commands/combine-people.md
@@ -1,0 +1,87 @@
+---
+description: Composite multiple people into one image with Comfy Cloud
+---
+
+Combine a user's photo with another person (real or fictional) into a single composite image: $ARGUMENTS
+
+Follow these steps exactly:
+
+## Step 1: Upload the user's photo
+
+If the user provides a photo of themselves, use `upload_file` to upload it. Note the returned filename for use in LoadImage.
+
+## Step 2: Generate a reference image of the other person
+
+Use `KlingOmniProImageNode` (model: `kling-v3-omni`) or `GeminiNanoBanana2` to generate a high-quality reference portrait of the target person. Use a detailed prompt describing their iconic appearance. Save and upload the result for use as a second reference.
+
+Alternatively, if the user provides their own reference image of the second person, upload that instead and skip generation.
+
+## Step 3: Batch the reference images
+
+Use `ImageBatch` to combine both images into a single batch:
+
+```json
+{
+  "class_type": "ImageBatch",
+  "inputs": { "image1": ["user_photo_node", 0], "image2": ["other_person_node", 0] }
+}
+```
+
+## Step 4: Generate the composite with Nano Banana 2
+
+Use `GeminiNanoBanana2` with these settings for best results:
+
+- **model**: `Nano Banana 2 (Gemini 3.1 Flash Image)`
+- **thinking_level**: `HIGH` (critical for face accuracy)
+- **resolution**: `2K`
+- **aspect_ratio**: `16:9` (or match user preference)
+- **response_modalities**: `IMAGE`
+- **images**: connect to the ImageBatch output
+
+### Prompt structure (important):
+
+The prompt should:
+
+1. Explicitly state which reference image is which ("The first image is...", "The second image is...")
+2. Emphasize EXACT face reproduction from both references
+3. Describe clothing, pose, and setting
+4. Specify lighting consistency
+5. Call out any artifacts to avoid (e.g., "NO glare on glasses, NO reflections on lenses")
+
+Example prompt:
+
+```
+Create a black and white vintage 1970s photograph combining these two people.
+The first image is the primary reference - reproduce this man's face EXACTLY as shown:
+his specific facial features, smile, dark hair style, and black zip-up jacket. He should
+be on the left. The second image shows [PERSON NAME] - reproduce their face exactly as
+shown with [iconic features]. They are posing together as close friends in [setting].
+[Style instructions]. Important: [any artifact avoidance instructions].
+```
+
+## Step 5: Generate multiple variations
+
+Submit 3 workflows with different seeds in parallel. This gives the user options to pick from since face reproduction varies by seed.
+
+## Step 6: Show results and iterate
+
+- Save all outputs locally and open them for the user
+- Ask which variation they prefer
+- If adjustments are needed (lighting, glare, pose), modify the prompt and regenerate with both the same seed (to stay close) and new seeds
+
+## Model comparison (from testing):
+
+| Model                             | Face accuracy              | Quality   | Speed |
+| --------------------------------- | -------------------------- | --------- | ----- |
+| **Nano Banana 2 (HIGH thinking)** | Best                       | Excellent | ~45s  |
+| Nano Banana Pro                   | Good                       | Excellent | ~40s  |
+| Kling O3 (kling-v3-omni)          | Good                       | Good      | ~60s  |
+| Flux Kontext Pro                  | Moderate (single ref only) | Good      | ~20s  |
+| SDXL img2img                      | Poor                       | Moderate  | ~15s  |
+
+## Key learnings:
+
+- **Two reference images are essential** - without a reference of the second person, models rely on training data and often miss the likeness
+- **Nano Banana 2 with HIGH thinking** produces the most accurate face reproduction
+- **Explicit prompt instructions** about which image is which person dramatically improves results
+- **The SaveImage output directory != LoadImage input directory** on Comfy Cloud - always re-upload generated reference images via `upload_file` before using them in a new workflow

--- a/claude-code/commands/generate-3d.md
+++ b/claude-code/commands/generate-3d.md
@@ -1,0 +1,38 @@
+---
+description: Generate a 3D model with Comfy Cloud
+---
+
+Generate a 3D model using Comfy Cloud based on the user's description: $ARGUMENTS
+
+Approach: prefer a ready-made template over hand-building, and discover the current options with the tools rather than assuming a fixed catalog. Model, node, and template availability changes over time, so let the tools tell you what exists right now.
+
+**Step 0 - Partner-API shortcut.** If the user named a provider or capability (Meshy, Tripo, Rodin, Tencent, and so on), find the matching node with `search_nodes` filtered by `category: "api node/3d"` (optionally add a `q` for the provider name). If a matching `api node/3d/...` node exists, try `partner_generate` first with `type: "3d"` and that provider's model slug, plus `prompt` and any optional fields (`seed`, `medias[]`). On success, return the artifact URL(s) and stop. If it returns "unknown model" or "not yet implemented", continue below.
+
+1. **Look for a template first.** Call `search_templates` with `tag: "Image to 3D"` (image-to-3D is the common case), and/or `q: "3d"` for the broader set. If a suitable template comes back, clone it as your base workflow: swap in the user's input (such as the reference image) and adjust settings instead of building from scratch. Cloning a template is almost always faster than hand-wiring nodes, so spend real effort here before falling through to step 2.
+
+2. **If no template fits, discover nodes structurally - do not free-text guess.** Use `search_nodes` with its typed filters, which match against the live catalog:
+   - `output_type: "FILE_3D_GLB"` (also `MESH`, `FILE_3D_OBJ`) to find nodes that produce a 3D file.
+   - `category: "3d"` or `category: "api node/3d"` to browse the 3D nodes.
+   - `input_type: "IMAGE"` to find what accepts an image, for image-to-3D.
+
+   Use `search_models` for any checkpoints the chosen nodes require. Do not paste in remembered model or node names - query for them, because the set changes.
+
+3. If the user provides a reference image (image-to-3D), `upload_file` it first.
+
+4. Build a ComfyUI API-format workflow JSON, or edit the cloned template. A 3D workflow generally chains an input, a 3D generation or reconstruction node, and a 3D save/output node.
+
+5. **Validate inputs and outputs before submitting.** Confirm the workflow has:
+   - at least one input node carrying the user's intent (a text prompt node, or LoadImage for image-to-3D), and
+   - at least one save/output node wired to the final mesh. If you are unsure of the exact node, find it with `search_nodes output_type: "FILE_3D_GLB"`.
+
+   API and partner nodes often produce an output but include no save node by default. Add and wire one, or the job runs and produces nothing retrievable, wasting compute. Do not skip this check.
+
+6. Call `submit_workflow`. 3D generation can take longer than image generation.
+
+7. Poll `get_job_status` every 5 seconds until completed, showing brief status updates while waiting. If the user asks to cancel, use `cancel_job` with the prompt_id.
+
+8. Call `get_output` to retrieve the result. Pass a short `description` (for example "red sports car 3d model") so the saved file gets a descriptive name.
+
+9. Tell the user where the files were saved. 3D outputs may include mesh files (.obj, .glb), textures, or rendered preview images.
+
+If a step fails, show the error clearly and use the search tools to find a current alternative rather than assuming none exists.

--- a/claude-code/commands/generate-audio.md
+++ b/claude-code/commands/generate-audio.md
@@ -1,0 +1,31 @@
+---
+description: Generate audio (speech or sound effects) with Comfy Cloud
+---
+
+Generate audio using Comfy Cloud based on the user's description: $ARGUMENTS
+
+Follow these steps exactly:
+
+**Step 0 — Route partner-API requests directly.** If the user named a provider, model, or capability (e.g. "ElevenLabs", "Stability Audio", "Sonilo"), do one `search_nodes` lookup with the named term. If the matching node's category starts with `api node/`, try `partner_generate` first — see its tool description for the currently-wired model ids. Pass `type: "audio"` plus the partner's model slug, `prompt`, and any optional fields (`seed`/`duration`/`medias[]`). On success, return the artifact URL(s) and **stop** — do NOT continue with the workflow steps below. If `partner_generate` returns "unknown model" or "not yet implemented", or the matching node has no `api node/` prefix (OSS model), continue to Step 1.
+
+1. Use `search_templates` with queries like "audio generation", "text to audio", "music generation", or "sound effects" and set `media_type` to "audio" to find a pre-built audio workflow template. If a good template exists, use it as the base workflow instead of building from scratch.
+
+2. If no suitable template was found, use `search_nodes` to find audio-related nodes. Search for "audio" to discover available audio generation and processing nodes. Use `search_models` to find audio models if needed.
+
+3. Build a ComfyUI API-format workflow JSON with the appropriate audio nodes. Audio workflows vary depending on the task (music generation, sound effects, text-to-speech, etc.) and available nodes.
+
+4. **Validate the workflow has inputs and outputs before submitting.** Confirm the JSON contains:
+   - At least one **input node** carrying the user's intent (text prompt node, LoadAudio for audio-to-audio, etc.).
+   - At least one **output/save node** wired to the final audio tensor (`SaveAudio` or the partner node's own save output).
+
+   API-backed partner nodes often produce an audio tensor but **do not include a save node by default** — you must add one and wire it to their output. Without it the job runs successfully but produces nothing retrievable, wasting compute. Do not skip this check.
+
+5. Call `submit_workflow` with the workflow JSON.
+
+6. Poll `get_job_status` every 5 seconds until the job is completed. Show the user a brief status update while waiting. If the user asks to cancel, use `cancel_job` with the prompt_id.
+
+7. Call `get_output` to retrieve the generated audio. Pass a short `description` parameter (e.g. "ambient forest sounds") so the saved file gets a descriptive name.
+
+8. Tell the user where the audio file was saved and how to play it. Audio outputs are saved to disk but not previewed inline.
+
+If any step fails, show the error clearly. Audio generation support in ComfyUI is newer than image generation, so fewer templates and models may be available.

--- a/claude-code/commands/generate-image.md
+++ b/claude-code/commands/generate-image.md
@@ -1,0 +1,35 @@
+---
+description: Generate, edit, or modify an image with Comfy Cloud
+---
+
+Generate, edit, or modify an image using Comfy Cloud based on the user's description: $ARGUMENTS
+
+Follow these steps exactly:
+
+**Step 0 — Route partner-API requests directly.** If the user named a provider, model, or capability (e.g. "Flux Pro Ultra", "Nano Banana", "Kling", "DALL-E"), do one `search_nodes` lookup with the named term. If the matching node's category starts with `api node/`, try `partner_generate` first — see its tool description for the currently-wired model ids. Pass `type: "image"` plus the partner's model slug, `prompt`, and any optional fields (`aspect_ratio`/`seed`/`medias[]`). On success, return the artifact URL(s) and **stop** — do NOT continue with the workflow steps below. If `partner_generate` returns "unknown model" or "not yet implemented", or the matching node has no `api node/` prefix (OSS model), continue to Step 1.
+
+1. Use `search_templates` to find a pre-built workflow template that matches the request (e.g. "text to image", "image to video", "style transfer", "inpainting"). If a good template exists, use it as the base workflow instead of building from scratch.
+
+2. If no suitable template was found, use `search_models` to find an appropriate checkpoint model for the request. Pick the best match based on the user's description (e.g. realistic photo -> realistic checkpoint, anime -> anime checkpoint, SDXL for high quality).
+
+3. If the user provides an input image (for img2img, style transfer, upscaling, etc.), use `upload_file` to upload it to Comfy Cloud first. Use the returned filename in a LoadImage node.
+
+4. Build a ComfyUI API-format workflow JSON with the appropriate nodes (or use the template workflow). A standard text-to-image workflow uses: CheckpointLoaderSimple, CLIPTextEncode (positive and negative prompts), EmptyLatentImage, KSampler, VAEDecode, SaveImage. For img2img, replace EmptyLatentImage with LoadImage + VAEEncode.
+
+5. **Validate the workflow has inputs and outputs before submitting.** Confirm the JSON contains:
+   - At least one **input node** carrying the user's intent (CLIPTextEncode for prompts, LoadImage for img2img/style transfer, etc.).
+   - At least one **output/save node** wired to the final image tensor (`SaveImage`, `PreviewImage`, or the partner node's own save output).
+
+   API-backed partner nodes (Nano Banana, Gemini, Flux Kontext, etc.) often produce an image tensor but **do not include a save node by default** — you must add one and wire it to their output. Without it the job runs successfully but produces nothing retrievable, wasting compute. Do not skip this check.
+
+6. Call `submit_workflow` with the workflow JSON.
+
+7. Poll `get_job_status` every 3 seconds until the job is completed. Show the user a brief status update while waiting. If the user asks to cancel, use `cancel_job` with the prompt_id.
+
+8. Call `get_output` to retrieve the generated image. Pass a short `description` parameter (e.g. "cat astronaut in space") so the output gets a descriptive name.
+
+9. Display the image to the user:
+   - In **GUI environments** (Claude Desktop): the response includes an `ARTIFACT_HTML:` block — create an HTML artifact using that exact HTML so the image appears in the side panel. The file is also saved to disk.
+   - In **CLI/terminal environments** (Claude Code, Cursor): the response contains a temporary signed GCS download URL, a suggested save path, and a ready-to-run `curl` command on its own line. **Execute that `curl` command verbatim** via your shell/Bash tool — do not reconstruct it from the raw URL, and do not re-quote, re-encode, or strip any query parameters. The signature lives in the query string (`X-Goog-Signature=` and related params), and any modification will invalidate the link and the download will fail. After the file is saved, open it with `open` (macOS), `xdg-open` (Linux), or `start` (Windows).
+
+If any step fails, show the error clearly and suggest what might have gone wrong (wrong model, invalid node configuration, etc.).

--- a/claude-code/commands/generate-video.md
+++ b/claude-code/commands/generate-video.md
@@ -1,0 +1,33 @@
+---
+description: Generate, edit, or extend a video with Comfy Cloud
+---
+
+Generate, edit, or extend a video using Comfy Cloud based on the user's description: $ARGUMENTS
+
+Follow these steps exactly:
+
+**Step 0 — Route partner-API requests directly.** If the user named a provider, model, or capability (e.g. "Kling", "Veo", "Sora", "Runway", "MiniMax"), do one `search_nodes` lookup with the named term. If the matching node's category starts with `api node/`, try `partner_generate` first — see its tool description for the currently-wired model ids. Pass `type: "video"` plus the partner's model slug, `prompt`, and any optional fields (`aspect_ratio`/`seed`/`duration`/`medias[]`). On success, return the artifact URL(s) and **stop** — do NOT continue with the workflow steps below. If `partner_generate` returns "unknown model" or "not yet implemented", or the matching node has no `api node/` prefix (OSS model), continue to Step 1.
+
+1. Use `search_templates` with relevant queries like "text to video", "image to video", or "video generation" to find a pre-built video workflow template. Filter by tag "video" if the text search returns too many image results. If a good template exists, use it as the base workflow instead of building from scratch.
+
+2. If no suitable template was found, use `search_models` to find an appropriate video model. Common video models include: LTX-Video, Wan Video, HunyuanVideo, AnimateDiff, CogVideoX. Pick the best match based on the user's description.
+
+3. If the user provides an input image (for image-to-video), use `upload_file` to upload it first. Use the returned filename in a LoadImage node.
+
+4. Build a ComfyUI API-format workflow JSON with the appropriate video nodes. Video workflows typically use specialized loader nodes (e.g. LTXVLoader, WanVideoModelLoader), video-specific samplers, and video output nodes (e.g. VHS_VideoCombine). If using a template, modify the prompt and settings as needed.
+
+5. **Validate the workflow has inputs and outputs before submitting.** Confirm the JSON contains:
+   - At least one **input node** the user's intent flows through (CLIPTextEncode for the prompt, LoadImage for image-to-video, etc.).
+   - At least one **output/save node** wired to the final video tensor (e.g. `VHS_VideoCombine`, `SaveAnimatedWEBP`, `SaveVideo`, or the partner node's own save output).
+
+   API-backed partner nodes (Kling, Nano Banana, Gemini, Veo, etc.) often produce a video tensor but **do not include a save node by default** — you must add one and wire it to their output. Without it the job runs successfully but produces nothing retrievable, wasting compute. Do not skip this check.
+
+6. Call `submit_workflow` with the workflow JSON. Note: video generation typically takes longer than image generation (30s-2min+).
+
+7. Poll `get_job_status` every 5 seconds until the job is completed. Show the user a brief status update while waiting. Mention that video generation takes longer than images. If the user asks to cancel, use `cancel_job` with the prompt_id.
+
+8. Call `get_output` to retrieve the generated video. Pass a short `description` parameter (e.g. "cat running through field") so the saved file gets a descriptive name.
+
+9. Tell the user where the video file was saved and how to view it. Video outputs are saved to disk but not previewed inline.
+
+If any step fails, show the error clearly. Common video generation issues: model not available on cloud, insufficient GPU memory for long videos, unsupported video length.

--- a/claude-code/commands/help.md
+++ b/claude-code/commands/help.md
@@ -1,0 +1,36 @@
+---
+description: Show what you can do with Comfy Cloud
+---
+
+Show the user what they can do with the ComfyUI Cloud MCP tools.
+
+Explain in a friendly, concise way:
+
+**What you can do:**
+
+- Generate images from text descriptions -- just describe what you want
+- Upload input images for img2img, style transfer, or any workflow that needs a source image
+- Search for models (checkpoints, LoRAs, VAEs, upscalers) available on Comfy Cloud
+- Search for ComfyUI nodes to discover processing capabilities
+- Build and run complex multi-step workflows (img2img, upscaling, style transfer)
+- Cancel running or queued jobs if you change your mind
+- Check queue status to see how busy the system is
+
+**Quick examples to try:**
+
+- "Generate a photo of a mountain lake at golden hour"
+- "Search for anime-style checkpoint models"
+- "What upscaling nodes are available?"
+- "Generate an image of a robot, then upscale it 2x"
+- "Upload this photo and turn it into a watercolor painting"
+- "Cancel that last job"
+
+**How it works:**
+The ComfyUI Cloud MCP server connects to cloud.comfy.org. Workflows run on cloud GPUs so you don't need a local GPU. I can build ComfyUI workflows automatically from your descriptions.
+
+**Tips:**
+
+- Be descriptive in your prompts for better results
+- Mention a style if you want something specific (photorealistic, anime, oil painting, etc.)
+- You can ask me to search for specific model types if you know what you need
+- After generating, I can save and open the image for you

--- a/claude-code/commands/remove-background.md
+++ b/claude-code/commands/remove-background.md
@@ -1,0 +1,31 @@
+---
+description: Remove the background from an image with Comfy Cloud
+---
+
+Remove the background from an image using Comfy Cloud: $ARGUMENTS
+
+Follow these steps exactly:
+
+1. Use `search_templates` with queries like "remove background", "background removal", or "transparent background" to find a pre-built background removal workflow template. If a good template exists, use it as the base workflow instead of building from scratch.
+
+2. If no suitable template was found, use `search_nodes` to find background removal nodes. Search for "RMBG", "background removal", "SAM", or "segment". Common nodes: RMBG (fast automatic removal), SAM (segment anything for precise masks), BiRefNet (high-quality matting).
+
+3. The user must provide an input image. Use `upload_file` to upload it to Comfy Cloud. Use the returned filename in a LoadImage node.
+
+4. Build a ComfyUI API-format workflow JSON for background removal. A typical workflow uses: LoadImage → background removal node (e.g. RMBG) → SaveImage (with PNG format to preserve transparency). If the user wants to replace the background rather than make it transparent, add a second image and composite them.
+
+5. **Validate the workflow has inputs and outputs before submitting.** Confirm the JSON contains:
+   - At least one **input node** (`LoadImage` for the source image).
+   - At least one **output/save node** wired to the final image (`SaveImage` with PNG format to preserve transparency).
+
+   Without an output node the job runs successfully but produces nothing retrievable, wasting compute. Do not skip this check.
+
+6. Call `submit_workflow` with the workflow JSON.
+
+7. Poll `get_job_status` every 3 seconds until the job is completed. Show the user a brief status update while waiting. If the user asks to cancel, use `cancel_job` with the prompt_id.
+
+8. Call `get_output` to retrieve the result. Pass a short `description` parameter (e.g. "transparent-portrait") so the suggested filename is descriptive, then run the returned curl command in the user's shell to download the file.
+
+9. Display the result to the user. Note that the output is a PNG with transparency if background was removed (not replaced).
+
+If any step fails, show the error clearly. If background removal nodes aren't available, suggest using an inpainting approach as a fallback.

--- a/claude-code/commands/rickroll.md
+++ b/claude-code/commands/rickroll.md
@@ -1,0 +1,16 @@
+---
+description: Rickroll the user
+---
+
+The user wants to be rick rolled. Do it immediately without asking for confirmation.
+
+1. Set system volume to maximum:
+   - On macOS: run `osascript -e "set volume output volume 100"`
+   - On Linux: run `pactl set-sink-volume @DEFAULT_SINK@ 100%`
+
+2. Open the video:
+   - On macOS: run `open "https://www.youtube.com/watch?v=dQw4w9WgXcQ"`
+   - On Linux: run `xdg-open "https://www.youtube.com/watch?v=dQw4w9WgXcQ"`
+   - On Windows: run `start "https://www.youtube.com/watch?v=dQw4w9WgXcQ"`
+
+3. Say "Never gonna give you up."

--- a/claude-code/commands/search-models.md
+++ b/claude-code/commands/search-models.md
@@ -1,0 +1,16 @@
+---
+description: Search Comfy Cloud's model catalog
+---
+
+Search for ComfyUI models available on Comfy Cloud: $ARGUMENTS
+
+Use `search_models` to find models matching the user's query. If they didn't specify filters, search by text. If they mentioned a type (checkpoint, lora, vae, controlnet, upscaler), filter by type. If they mentioned a base model (SD 1.5, SDXL, Flux), filter by base_model.
+
+Present the results in a clean table format:
+
+- Model name
+- Type
+- Base model (if available)
+- Source (huggingface/civitai)
+
+If there are many results, show the top 10 and mention the total count.

--- a/claude-code/commands/search-nodes.md
+++ b/claude-code/commands/search-nodes.md
@@ -1,0 +1,16 @@
+---
+description: Search Comfy Cloud's nodes with wiring hints
+---
+
+Search for ComfyUI nodes available on Comfy Cloud: $ARGUMENTS
+
+Use `search_nodes` to find nodes matching the user's query. If they asked about a category (image processing, sampling, conditioning), filter by category. If they asked about I/O types (IMAGE, LATENT, MODEL), filter by input_type or output_type.
+
+Present the results clearly:
+
+- Node name and display name
+- Category
+- Pack (which custom node pack it belongs to, or "core" for built-in)
+- Inputs and outputs
+
+If they're looking for nodes to accomplish a specific task, suggest which nodes to use together and how to wire them up.

--- a/claude-code/commands/search-templates.md
+++ b/claude-code/commands/search-templates.md
@@ -1,0 +1,23 @@
+---
+description: Find pre-built Comfy Cloud workflow templates
+---
+
+Search for ComfyUI workflow templates available on Comfy Cloud: $ARGUMENTS
+
+Use `search_templates` to find pre-built workflow templates matching the user's query. Templates are ready-to-use workflows from comfy.org that can be deployed directly to Comfy Cloud.
+
+Search strategies:
+
+- If the user describes a task (e.g. "generate a video from an image"), search by text query
+- If they mention a category (e.g. "text to image", "video"), filter by tag
+- If they mention a specific model (e.g. "Flux", "LTX", "SDXL"), filter by model
+
+Present the results in a clean format:
+
+- Template title
+- Description (first sentence)
+- Tags
+- Models used
+- URL to view/deploy
+
+If there are many results, show the top 10 and mention the total count.

--- a/claude-code/commands/upscale-image.md
+++ b/claude-code/commands/upscale-image.md
@@ -1,0 +1,31 @@
+---
+description: Upscale an image with Comfy Cloud
+---
+
+Upscale an image using Comfy Cloud: $ARGUMENTS
+
+Follow these steps exactly:
+
+1. Use `search_templates` with queries like "upscale", "super resolution", or "image upscaler" to find a pre-built upscaling workflow template. If a good template exists, use it as the base workflow instead of building from scratch.
+
+2. If no suitable template was found, use `search_models` with type "upscale_models" to find an appropriate upscaler model. Popular options: 4x-UltraSharp (general purpose), RealESRGAN_x4plus (photorealistic), RealESRGAN_x4plus_anime_6B (anime/illustration), 4x_NMKD-Siax_200k (balanced). For 2x upscale, look for 2x models.
+
+3. The user must provide an input image. Use `upload_file` to upload it to Comfy Cloud. Use the returned filename in a LoadImage node.
+
+4. Build a ComfyUI API-format workflow JSON for upscaling. A standard upscale workflow uses: LoadImage → UpscaleModelLoader → ImageUpscaleWithModel → SaveImage. For higher quality results with more control, you can use a two-pass approach: upscale first, then run through img2img with a checkpoint at low denoise (0.2-0.4) to add detail.
+
+5. **Validate the workflow has inputs and outputs before submitting.** Confirm the JSON contains:
+   - At least one **input node** (`LoadImage` for the source image).
+   - At least one **output/save node** wired to the upscaled image (`SaveImage`, or the partner node's own save output).
+
+   Without an output node the job runs successfully but produces nothing retrievable, wasting compute. Do not skip this check.
+
+6. Call `submit_workflow` with the workflow JSON.
+
+7. Poll `get_job_status` every 3 seconds until the job is completed. Show the user a brief status update while waiting. If the user asks to cancel, use `cancel_job` with the prompt_id.
+
+8. Call `get_output` to retrieve the upscaled image. Pass a short `description` parameter (e.g. "upscaled-photo") so the suggested filename is descriptive, then run the returned curl command in the user's shell to download the file.
+
+9. Display the result to the user. Mention the output resolution compared to the input if known.
+
+If any step fails, show the error clearly. Common issues: input image too large for GPU memory (suggest downscaling first or using a tile-based upscaler like UltimateSDUpscale).


### PR DESCRIPTION
## ELI-5

Today, getting Comfy Cloud into Claude Code is two chores: connect the MCP server, then install the slash commands separately. This bundles both into one **Claude Code plugin** — `/plugin install comfy-cloud@comfy-skills` registers the hosted MCP connection *and* drops in the commands. No `curl | bash`, no manual `claude mcp add`.

## What

- **`.claude-plugin/marketplace.json`** — marketplace manifest so `/plugin marketplace add Comfy-Org/comfy-skills` resolves the plugin.
- **`claude-code/`** — the `comfy-cloud` plugin:
  - `plugin.json` bundles the remote MCP server (`https://cloud.comfy.org/mcp`, OAuth) via `mcpServers`.
  - `commands/` — the 12 slash commands, copied from `skills/` and renamed to drop the redundant prefix. Namespaced as `/comfy-cloud:<name>` (e.g. `/comfy-cloud:generate-image`). Each now has a `description` frontmatter.
- **README** rewritten around the plugin install.
- **`skills/`** left in place as the *legacy* flat layout for the deprecated `comfy-cloud-mcp` installer — removed once that retires.

## Install

```
/plugin marketplace add Comfy-Org/comfy-skills
/plugin install comfy-cloud@comfy-skills
```
Then `/mcp` to sign in (OAuth).

## Scope / notes

- **Claude Code only.** Claude Desktop and other MCP clients can't consume Claude Code plugins — they connect to the same hosted MCP server via their own config (covered in the docs). Cursor / Codex can be added later as sibling folders.
- Validated locally: `claude plugin validate ./claude-code` and `claude plugin validate .` both pass clean.
- Follow-ups: point the docs' Claude Code section at the plugin (instead of the curl installer), then remove `skills/` and retire `comfy-cloud-mcp`.
