### PR TITLE
ci: onboard unreviewed-merge detector

### DIFF
--- a/.github/workflows/detect-unreviewed-merge.yml
+++ b/.github/workflows/detect-unreviewed-merge.yml
@@ -1,0 +1,24 @@
+# Detects merges to main that landed without an approving review and opens a
+# tracking issue in Comfy-Org/unreviewed-merges (SOC 2). Detection logic lives
+# in the reusable workflow; this caller just wires it up.
+name: Detect Unreviewed Merge
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: detect-unreviewed-merge-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect:
+    uses: Comfy-Org/github-workflows/.github/workflows/detect-unreviewed-merge.yml@4d9cb6b87f953bb7cd69954280e1465fb9bd2040 # v1
+    with:
+      approval-mode: latest-per-reviewer
+    secrets:
+      UNREVIEWED_MERGES_TOKEN: ${{ secrets.UNREVIEWED_MERGES_TOKEN }}


### PR DESCRIPTION
## What

Onboards this repo to the SOC 2 **unreviewed-merge detector** ([Comfy-Org/unreviewed-merges](https://github.com/Comfy-Org/unreviewed-merges)). Adds the ~20-line caller workflow that, on every push to `main`, opens a tracking issue if the merged PR had no approving review.

Config: `branches: [main]`, `approval-mode: latest-per-reviewer` (this repo dismisses stale reviews).

## Why now

Admin bypass of branch protection was just enabled on this repo, so admins can merge to `main` without a review. The detector is what keeps those bypasses tracked for compliance — enabling bypass without it leaves a gap.

## ⚠️ Blocked on a prerequisite (draft)

The org secret **`UNREVIEWED_MERGES_TOKEN` is not yet shared with this repo**, so the detector job will fail until an org admin grants it (Org → Settings → Secrets and variables → Actions → `UNREVIEWED_MERGES_TOKEN` → add this repo). Kept as **draft** until that's done; mark ready + merge afterward.
