### PR TITLE
feat: add OpenClaw skill for the hosted Comfy Cloud MCP

### DIFF
--- a/openclaw/comfy/SKILL.md
+++ b/openclaw/comfy/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: comfy
+description: Generate images, video, audio, and 3D with Comfy Cloud — search hundreds of models and workflow templates, run custom ComfyUI workflows, and manage generation jobs through the hosted Comfy MCP server. Use for any "generate/edit an image", "make a video", "text to 3D", or ComfyUI workflow task.
+---
+
+# Comfy Cloud
+
+Comfy Cloud runs [ComfyUI](https://www.comfy.org) in the cloud and exposes it to
+agents as an MCP server: image/video/audio/3D generation via partner models
+(Ideogram, Flux, Kling, Veo, Seedance, and more) and open-source pipelines,
+plus full ComfyUI workflow authoring — search templates, override inputs,
+submit custom graphs, and fetch outputs as signed URLs.
+
+## Connect
+
+1. **Get an API key** — sign in at [cloud.comfy.org](https://cloud.comfy.org),
+   then create a key under **Settings → API Keys**. Keys start with `comfyui-`.
+   (Browsing/search tools work with any account; generation consumes Comfy
+   Cloud credits and needs a subscription or credit balance.)
+
+2. **Export it** (put this in your shell profile or OpenClaw's env):
+
+   ```bash
+   export COMFY_API_KEY="comfyui-..."
+   ```
+
+3. **Register the MCP server with OpenClaw:**
+
+   ```bash
+   openclaw mcp set comfy '{"url":"https://cloud.comfy.org/mcp","transport":"streamable-http","headers":{"Authorization":"Bearer ${COMFY_API_KEY}"}}'
+   openclaw gateway restart
+   ```
+
+   The server also accepts the key as an `X-API-Key: ${COMFY_API_KEY}` header,
+   but prefer the `Authorization: Bearer` form above — standard headers survive
+   every client's proxy layer, and some OpenClaw builds have dropped custom
+   headers on streamable-http transports (see openclaw#65590). If you get a
+   `401` with a key you know is valid, you are probably hitting that: switch to
+   the Bearer form or route through mcporter.
+
+## Which tools to use
+
+**Images and video from a named model** (Ideogram, Flux, Gemini, Kling, Veo,
+Seedance, …): call `partner_generate` — it runs the provider through Comfy
+Cloud and saves the result to your asset library. Do not hand-build a workflow
+for plain text-to-image/video when a partner model is named.
+
+**Anything workflow-shaped** (open-source models, LoRA/ControlNet, multi-step
+pipelines): start from a template — `search_templates` → `get_template_schema`
+→ `run_template` with `input_overrides`. For fully custom graphs use
+`submit_workflow` (the graph must end in an output node like SaveImage, or
+validation rejects it). Save and reuse with `save_workflow` /
+`run_saved_workflow`.
+
+**Editing an existing image**: `upload_file` first, then reference the
+uploaded file from a LoadImage node (or pass it to `partner_generate` for
+image-to-image partners). Never inline base64 image data into a workflow.
+
+**Getting results**: `wait_for_job` → `get_output`. Outputs come back as
+time-limited signed URLs — download them exactly as returned (don't edit query
+params, they're part of the signature). `get_queue` and `cancel_job` manage
+in-flight jobs; `submit_batch` / `wait_for_batch` fan out variations.
+
+**Discovery**: `search_models` (checkpoints/LoRAs on the platform),
+`search_nodes` (available ComfyUI nodes with wiring hints),
+`get_prompting_guide` (model-specific prompting advice).
+
+## Example prompts
+
+- "Generate an image of a cozy bookstore café on a rainy afternoon with
+  Ideogram and download it to ./bookstore.png"
+- "Take ./product.jpg, remove the background, and upscale the result 2×"
+- "Find a text-to-video template for Kling, run it with the prompt 'a paper
+  boat drifting down a rain gutter, cinematic', and give me the output URL"
+
+## Notes
+
+- Generation spends Comfy Cloud credits; search/discovery tools are free.
+- Full MCP docs and per-client setup: [docs.comfy.org/cloud/mcp](https://docs.comfy.org/cloud/mcp)


### PR DESCRIPTION
## ELI-5

OpenClaw is another AI agent platform, and its users install "skills" the way Claude Code users install plugins. This adds the Comfy skill for it: a single instruction file that teaches an OpenClaw agent how to connect to the hosted Comfy Cloud MCP server with an API key and which tools to reach for when someone asks it to generate images, video, audio, 3D, or run ComfyUI workflows.

## What

- `openclaw/comfy/SKILL.md` — the skill, in ClawHub's expected shape (frontmatter `name` + `description`, instruction body). Pure markdown, zero dependencies (keeps the ClawHub VirusTotal scan trivially clean).
- Connection section registers the hosted server via `openclaw mcp set` using **`Authorization: Bearer ${COMFY_API_KEY}`** as the primary header form, with `X-API-Key` documented as the alternative.

## Why Bearer-first

Both header forms are accepted by the hosted MCP endpoint (verified live: unauthenticated → 401, Bearer → 200, X-API-Key → 200). Bearer is the standard header every client and proxy layer handles — and some OpenClaw builds have a known issue dropping custom headers on streamable-http transports (openclaw#65590), which the Bearer form sidesteps entirely.

## Not in this PR

- ClawHub publication (`clawhub skill publish`) — needs the official comfy-org ClawHub identity; tracked in the Slack thread that kicked this off.
- A local `openclaw agent` smoke test — needs an OpenClaw account/gateway; whoever publishes should run the load test from the skill folder first.
