### PR TITLE
fix(technique-combine-people): name current node classes, not deprecated ones

### DIFF
--- a/skills/technique-combine-people.md
+++ b/skills/technique-combine-people.md
@@ -8,31 +8,31 @@ If the user provides a photo of themselves, use `upload_file` to upload it. Note
 
 ## Step 2: Generate a reference image of the other person
 
-Use `KlingOmniProImageNode` (model: `kling-v3-omni`) or `GeminiNanoBanana2` to generate a high-quality reference portrait of the target person. Use a detailed prompt describing their iconic appearance. Save and upload the result for use as a second reference.
+Use `KlingOmniProImageNode` (model: `kling-v3-omni`) or `GeminiNanoBanana2V2` to generate a high-quality reference portrait of the target person. Use a detailed prompt describing their iconic appearance. Save and upload the result for use as a second reference.
+
+`GeminiNanoBanana2V2` is the current class name — the older `GeminiNanoBanana2` is marked deprecated in the node catalog and is hidden from `search_nodes`.
 
 Alternatively, if the user provides their own reference image of the second person, upload that instead and skip generation.
 
-## Step 3: Batch the reference images
+## Step 3: Wire both references into the composite node
 
-Use `ImageBatch` to combine both images into a single batch:
+`GeminiNanoBanana2V2` takes up to 14 reference images directly, as auto-grow slots named `model.images.image_1` through `model.images.image_14`, so no separate batching node is needed — connect the user's photo to `model.images.image_1` and the other person to `model.images.image_2`.
 
-```json
-{
-  "class_type": "ImageBatch",
-  "inputs": { "image1": ["user_photo_node", 0], "image2": ["other_person_node", 0] }
-}
-```
+If you do need a standalone image batch elsewhere in the graph, the current class is `BatchImagesNode` (display name "Batch Images"); the older `ImageBatch` is marked deprecated. Its `images` input is an auto-grow list, so call `get_node({ names: ["BatchImagesNode"] })` for the exact slot names before wiring it.
 
 ## Step 4: Generate the composite with Nano Banana 2
 
-Use `GeminiNanoBanana2` with these settings for best results:
+`GeminiNanoBanana2V2`'s `model` input is a dynamic combo, so the settings it gates are sent under their full dotted names, not flat. Call `get_node({ names: ["GeminiNanoBanana2V2"] })` for the exact input names before you build the graph.
+
+Settings that matter for this recipe:
 
 - **model**: `Nano Banana 2 (Gemini 3.1 Flash Image)`
-- **thinking_level**: `HIGH` (critical for face accuracy)
-- **resolution**: `2K`
-- **aspect_ratio**: `16:9` (or match user preference)
-- **response_modalities**: `IMAGE`
-- **images**: connect to the ImageBatch output
+- **model.thinking_level**: `HIGH` (critical for face accuracy)
+- **model.resolution**: `2K`
+- **model.aspect_ratio**: `16:9` (or match user preference)
+- **model.images.image_1** / **model.images.image_2**: the two references from Step 3
+- **response_modalities**: `IMAGE` (top level, not gated by `model`)
+- **seed**: top level; vary it for Step 5
 
 ### Prompt structure (important):
 


### PR DESCRIPTION
The `technique-combine-people` recipe instructs agents to build with `ImageBatch` and to generate with `GeminiNanoBanana2`. Both are `deprecated: true` in the Comfy Cloud node catalog — `ImageBatch`'s display name is literally `Batch Images (DEPRECATED)` — and the Comfy Cloud MCP server's `search_nodes` hides deprecated nodes by default (BE-3314).

So an agent that follows the recipe and then searches for the classes it just used gets nothing back. The workflows still *run* (deprecated nodes execute), so this is guidance quality rather than breakage — but it is exactly the inconsistency the deprecation filter exists to avoid, and this recipe is about to be served through the MCP server as `get_creative_technique` / `comfy://guides/techniques/combine-people` ([comfy-cloud-mcp-server#991](https://github.com/Comfy-Org/comfy-cloud-mcp-server/pull/991), BE-5442). Caught in review there.

## What changed

Verified against the bundled `object_info` catalog (`data/object_info.json.gz` in comfy-cloud-mcp-server), not guessed:

| Old | Status | Current |
| :-- | :-- | :-- |
| `ImageBatch` | `deprecated: true`, display name `Batch Images (DEPRECATED)` | `BatchImagesNode` (`deprecated: false`, display name `Batch Images`) |
| `GeminiNanoBanana2` | `deprecated: true` | `GeminiNanoBanana2V2` (`deprecated: false`, same display name `Nano Banana 2`) |

- **Step 2/4 → `GeminiNanoBanana2V2`.** Its `model` input is a `COMFY_DYNAMICCOMBO_V3`, so the settings it gates are addressed by their dotted names (`model.thinking_level`, `model.resolution`, `model.aspect_ratio`, `model.images.*`) rather than flat, as they were on the old class. `seed` and `response_modalities` are top level on the new class and stay top level in the recipe — the settings list now says which is which, because sending a gated sub-field flat fails with `required_input_missing`.
- **Step 3 no longer needs a batching node.** `GeminiNanoBanana2V2` takes up to 14 references directly, as auto-grow slots `model.images.image_1` … `model.images.image_14`, so the two references wire straight in. This is what removes the `ImageBatch` recommendation rather than merely swapping it.
- **`BatchImagesNode` is kept only as an aside** for graphs that do want a standalone batch. The recipe points at `get_node({ names: ["BatchImagesNode"] })` for the slot names instead of stating them: its `images` input is an auto-grow list with no enumerated slot names in the catalog, so the old literal `{"image1": ..., "image2": ...}` JSON snippet would have been a guess. Dropped rather than re-guessed.

Both old class names are still mentioned, each on a line that says it is deprecated. That is deliberate: an agent holding the old name should be redirected, not dead-ended.

Nothing else in the recipe changed — the prompt-structure guidance, example prompt, model-comparison table, and key learnings are untouched.

## Why it matters here rather than downstream

`Comfy-Org/comfy-skills` is the single source of truth; comfy-cloud-mcp-server mirrors `skills/*.md` into `data/skills.json` daily via `refresh-skills.yml`. A fix made only in that snapshot is reverted by the next refresh, so the edit lands here. comfy-cloud-mcp-server#991 carries the matching snapshot patch (so the surface ships correct on day one) plus a lint that fails CI if a refresh ever reintroduces a deprecated class into a served recipe.