### PR TITLE
docs(skills): add technique-transparent-subject-compositing recipe

### DIFF
--- a/skills/technique-transparent-subject-compositing.md
+++ b/skills/technique-transparent-subject-compositing.md
@@ -2,6 +2,13 @@ Composite a semi-transparent subject into a scene so the background shows throug
 
 Use this when the user wants a ghostly, holographic, or partially see-through character in a scene — typically as the reference or first frame for a video model such as Seedance. Prompting alone will not get you there; the transparency has to be a compositing step you control, not a phrase in the prompt.
 
+Before building this by hand, run `search_templates` — a ready-made template you can clone beats hand-wiring, and the catalog moves.
+
+Check first that you need this recipe rather than a simpler one, because "transparent" covers two different asks:
+
+- **A subject on a transparent background** (an alpha cutout, no scene) — that is native RGBA generation, not compositing. Use the Layer Diffuse family (`LayeredDiffusionApply` into `LayeredDiffusionDecodeRGBA`), or segment an existing image and keep the alpha. Do not use this recipe.
+- **A subject that is itself see-through, with a scene visible through it** — that is this recipe. The scene behind the subject has to be reconstructed before anything can show through, which is what Steps 2-4 do.
+
 Follow these steps exactly.
 
 ## Step 1: Generate the subject and the background together in one image
@@ -12,7 +19,7 @@ Use whichever image node the user's request points at, e.g. `GeminiNanoBanana2V2
 
 Prompt for a fully opaque, normally-lit character. Transparency is applied in Step 4; asking for it here just makes the model guess.
 
-Keep this image. It is used three more times: as the segmentation input, as the IPAdapter reference, and as the composite source.
+Keep this image. It is used three more times: as the segmentation input, as the IPAdapter reference, and as the composite source. Steps 1-4 can be one workflow; if you split them across submissions, re-upload the generated image with `upload_file` first — on Comfy Cloud the `SaveImage` output directory is not the `LoadImage` input directory.
 
 ## Step 2: Segment the subject out of that image
 
@@ -125,7 +132,7 @@ Scale the mask to set opacity, then composite:
 }
 ```
 
-`ImageCompositeMasked` blends per pixel by mask value, so a mask multiplied down to `0.45` gives a 45% character over a 100% background — the background genuinely shows through, and `value` is a dial the user can move without regenerating anything. `SolidMask`'s `width`/`height` must match the image; run `FeatherMask` on the tight mask first if the edge reads as cut out.
+`ImageCompositeMasked` blends per pixel by mask value, so a mask multiplied down to `0.45` gives a 45% character over a 100% background — the background genuinely shows through, and `value` is a dial the user can move without regenerating anything. Size `SolidMask` to the image: `MaskComposite` multiplies only where the two masks overlap and does not resize, so a short `SolidMask` silently leaves the rest of the character at full opacity. Run `FeatherMask` on the tight mask first if the edge reads as cut out.
 
 If a downstream step needs the character as a standalone RGBA layer instead of a flattened frame, use `JoinImageWithAlpha` (`image` = original image, `alpha` = faded mask).
 

--- a/skills/technique-transparent-subject-compositing.md
+++ b/skills/technique-transparent-subject-compositing.md
@@ -25,15 +25,17 @@ Keep this image. It is used three more times: as the segmentation input, as the 
 
 Produce a `MASK` covering the character. Pick the node that fits how the character has to be identified:
 
-| Node | What it needs | Good for |
-| --- | --- | --- |
-| `SAM3Segment` | a text `prompt` (e.g. "the woman in the red coat") | Naming one subject in a scene that contains several |
-| `BiRefNetRMBG` | just `image` plus a `model` choice | Clean single-subject cutouts; `BiRefNet-matting` for hair and soft edges |
-| `LayerMask: BiRefNetUltraV2` (+ `LayerMask: LoadBiRefNetModelV2`) | a loaded `BIREFNET_MODEL` | The same family with explicit `detail_erode` / `detail_dilate` / black-and-white-point controls |
-| `SAM3Segmentation` (+ `LoadSAM3Model`) | point or box prompts | Precise manual control when a text prompt picks the wrong thing |
-| `RemoveBackground` (+ `LoadBackgroundRemovalModel`) | a loaded `BACKGROUND_REMOVAL` model | Core-node path, mask output only |
+| Node | What it needs | `MASK` slot | Good for |
+| --- | --- | --- | --- |
+| `SAM3Segment` | a text `prompt` (e.g. "the woman in the red coat") | 1 | Naming one subject in a scene that contains several |
+| `BiRefNetRMBG` | just `image` plus a `model` choice | 1 | Clean single-subject cutouts; `BiRefNet-matting` for hair and soft edges |
+| `LayerMask: BiRefNetUltraV2` (+ `LayerMask: LoadBiRefNetModelV2`) | a loaded `BIREFNET_MODEL` | 1 | The same family with explicit `detail_erode` / `detail_dilate` / black-and-white-point controls |
+| `SAM3Segmentation` (+ `LoadSAM3Model`) | point or box prompts | 0 | Precise manual control when a text prompt picks the wrong thing |
+| `RemoveBackground` (+ `LoadBackgroundRemovalModel`) | a loaded `BACKGROUND_REMOVAL` model | 0 | Core-node path, mask output only |
 
 `SAM3Segment` and `BiRefNetRMBG` are single self-contained nodes (no separate loader), so they are the cheapest place to start.
+
+**The `MASK` output is not always slot 0.** `SAM3Segment` and `BiRefNetRMBG` both return `[IMAGE, MASK, MASK_IMAGE]`, so their mask is slot **1** — wiring `[node, 0]` hands an `IMAGE` to a `MASK` input and fails validation before the workflow runs. The column above is a starting point, not a guarantee; confirm the slot with `get_node` for whichever node you land on.
 
 Keep **two** versions of this mask:
 
@@ -43,7 +45,7 @@ Keep **two** versions of this mask:
 ```json
 {
   "class_type": "GrowMask",
-  "inputs": { "mask": ["segmentation_node", 0], "expand": 12, "tapered_corners": true }
+  "inputs": { "mask": ["segmentation_node", 1], "expand": 12, "tapered_corners": true }
 }
 ```
 
@@ -96,6 +98,26 @@ Prompt the inpaint for the background only — describe what should be behind th
 
 The output of this step is the reconstructed **background plate**: the same scene, no character, lighting and perspective intact.
 
+One refinement worth making: `noise_mask: true` confines the *denoising* to the hole, but `VAEDecode` still round-trips every pixel through the VAE, so the untouched scene comes back very slightly softened. Paste the fill back over the original to get a pristine plate:
+
+```json
+{
+  "clean_plate": {
+    "class_type": "ImageCompositeMasked",
+    "inputs": {
+      "destination": ["original_image", 0],
+      "source": ["vae_decode", 0],
+      "x": 0,
+      "y": 0,
+      "resize_source": false,
+      "mask": ["grow_mask", 0]
+    }
+  }
+}
+```
+
+This keeps the inpainted pixels inside the grown mask and the original pixels everywhere else.
+
 ## Step 4: Recomposite the subject at a controllable opacity
 
 You now hold two aligned layers at the same resolution: the original image (character in place) and the background plate. Because the character was never moved, compositing needs no alignment work — the tight mask from Step 2 puts it back exactly where it was.
@@ -111,7 +133,7 @@ Scale the mask to set opacity, then composite:
   "faded_mask": {
     "class_type": "MaskComposite",
     "inputs": {
-      "destination": ["tight_mask", 0],
+      "destination": ["segmentation_node", 1],
       "source": ["opacity", 0],
       "x": 0,
       "y": 0,
@@ -134,7 +156,22 @@ Scale the mask to set opacity, then composite:
 
 `ImageCompositeMasked` blends per pixel by mask value, so a mask multiplied down to `0.45` gives a 45% character over a 100% background — the background genuinely shows through, and `value` is a dial the user can move without regenerating anything. Size `SolidMask` to the image: `MaskComposite` multiplies only where the two masks overlap and does not resize, so a short `SolidMask` silently leaves the rest of the character at full opacity. Run `FeatherMask` on the tight mask first if the edge reads as cut out.
 
-If a downstream step needs the character as a standalone RGBA layer instead of a flattened frame, use `JoinImageWithAlpha` (`image` = original image, `alpha` = faded mask).
+If a downstream step needs the character as a standalone RGBA layer instead of a flattened frame, use `JoinImageWithAlpha` — but **invert the faded mask first**:
+
+```json
+{
+  "alpha_mask": {
+    "class_type": "InvertMask",
+    "inputs": { "mask": ["faded_mask", 0] }
+  },
+  "rgba_layer": {
+    "class_type": "JoinImageWithAlpha",
+    "inputs": { "image": ["original_image", 0], "alpha": ["alpha_mask", 0] }
+  }
+}
+```
+
+`JoinImageWithAlpha` computes `alpha = 1.0 - mask` internally, because ComfyUI's `MASK` convention is the inverse of alpha. Passing the faded mask straight in therefore produces the opposite of what you want — a fully opaque background (α = 1.0) with the character at α = 0.55. The `InvertMask` cancels that out, giving the character α = 0.45 and everything else α = 0. Note that this is the one place in the recipe where the mask has to be flipped: `ImageCompositeMasked` above takes the mask the right way round.
 
 ## Step 5: Hand the composite to the video model
 

--- a/skills/technique-transparent-subject-compositing.md
+++ b/skills/technique-transparent-subject-compositing.md
@@ -90,7 +90,7 @@ Wire it as: checkpoint → IPAdapter → inpaint conditioning → sampler → de
 }
 ```
 
-Then run `KSampler` with `model` from the `IPAdapterAdvanced` output (not the raw checkpoint — that is what applies the IPAdapter conditioning) and `positive` / `negative` / `latent_image` from `inpaint_cond`'s three outputs, and decode with `VAEDecode`. `VAEEncodeForInpaint` is the alternative latent path if the checkpoint is not an inpainting model; it takes its own `grow_mask_by`, so you can skip the separate `GrowMask` on that branch.
+Then run `KSampler` with `model` from the `IPAdapterAdvanced` output (not the raw checkpoint — that is what applies the IPAdapter conditioning) and `positive` / `negative` / `latent_image` from `inpaint_cond`'s three outputs, and decode with `VAEDecode`. `VAEEncodeForInpaint` is the alternative latent path if the checkpoint is not an inpainting model; it takes its own `grow_mask_by`, which covers the growing **for the latent only**. Keep the standalone `GrowMask` even on that branch: `VAEEncodeForInpaint` returns just a `LATENT` — the grown mask lives inside it as a `noise_mask` and is never exposed as a `MASK` output — so `IPAdapterAdvanced`'s `attn_mask` has nothing to wire to without it, and an unset `attn_mask` lets the IPAdapter condition the whole frame instead of just the hole.
 
 Two things to resolve at run time rather than assume: `IPAdapterUnifiedLoader` needs IPAdapter and CLIP-vision weights compatible with the checkpoint (use `search_models`, or wire `IPAdapterModelLoader` + `CLIPVisionLoader` explicitly via `IPAdapterAdvanced`'s `clip_vision` input), and the enum values above (`preset`, `weight_type`, `embeds_scaling`) should be confirmed with `get_node` before submitting.
 
@@ -154,7 +154,7 @@ Scale the mask to set opacity, then composite:
 }
 ```
 
-`ImageCompositeMasked` blends per pixel by mask value, so a mask multiplied down to `0.45` gives a 45% character over a 100% background — the background genuinely shows through, and `value` is a dial the user can move without regenerating anything. Size `SolidMask` to the image: `MaskComposite` multiplies only where the two masks overlap and does not resize, so a short `SolidMask` silently leaves the rest of the character at full opacity. Run `FeatherMask` on the tight mask first if the edge reads as cut out.
+`ImageCompositeMasked` blends per pixel by mask value, so a mask multiplied down to `0.45` gives a 45% character over a 100% background — the background genuinely shows through, and `value` is a dial the user can move without regenerating anything. Size `SolidMask` to the image — the `1280x720` above is a placeholder, so set `width` / `height` to the actual dimensions of the Step 1 image. `MaskComposite` multiplies only where the two masks overlap and does not resize, so a `SolidMask` smaller than the image silently leaves the rest of the character at full opacity. Run `FeatherMask` on the tight mask first if the edge reads as cut out.
 
 If a downstream step needs the character as a standalone RGBA layer instead of a flattened frame, use `JoinImageWithAlpha` — but **invert the faded mask first**:
 
@@ -177,7 +177,7 @@ If a downstream step needs the character as a standalone RGBA layer instead of a
 
 The composited frame is a normal image, so it feeds any image-conditioned video node — for the Seedance case, `ByteDance2ReferenceNode` (reference-to-video) or `ByteDance2FirstLastFrameNode` (first-frame). These gate their inputs behind a dynamic `model` combo, so call `get_node` for the exact slot names before wiring, and confirm the current class with `search_nodes` (`category: "partner/video"`).
 
-Save the background plate and the tight mask alongside the composite. Regenerating a different opacity, or re-cutting the composite for another shot, is then a Step 4 re-run rather than a full rebuild.
+Save the background plate, the tight mask, **and the original Step 1 image** alongside the composite. Step 4 consumes all three — the original is the composite *source*, not just the segmentation input — so dropping it means a full rebuild rather than a re-run. With all three kept, regenerating a different opacity or re-cutting the composite for another shot is a Step 4 re-run.
 
 ## Key learnings:
 

--- a/skills/technique-transparent-subject-compositing.md
+++ b/skills/technique-transparent-subject-compositing.md
@@ -1,0 +1,144 @@
+Composite a semi-transparent subject into a scene so the background shows through, by generating subject and background together, segmenting the subject out, inpainting the hole it leaves, and recompositing at a controllable opacity.
+
+Use this when the user wants a ghostly, holographic, or partially see-through character in a scene — typically as the reference or first frame for a video model such as Seedance. Prompting alone will not get you there; the transparency has to be a compositing step you control, not a phrase in the prompt.
+
+Follow these steps exactly.
+
+## Step 1: Generate the subject and the background together in one image
+
+Generate the character **in** the scene, in a single image, from a single prompt. Do not generate the character and the background separately — that is the failure mode this recipe exists to avoid (see Key learnings).
+
+Use whichever image node the user's request points at, e.g. `GeminiNanoBanana2V2` or `KlingOmniProImageNode`. Node availability moves, so confirm the current class with `search_nodes` (`category: "partner/image"`) rather than assuming, and call `get_node` for the exact input slot names — several of these nodes gate their settings behind a dynamic `model` combo and take dotted input names like `model.resolution`.
+
+Prompt for a fully opaque, normally-lit character. Transparency is applied in Step 4; asking for it here just makes the model guess.
+
+Keep this image. It is used three more times: as the segmentation input, as the IPAdapter reference, and as the composite source.
+
+## Step 2: Segment the subject out of that image
+
+Produce a `MASK` covering the character. Pick the node that fits how the character has to be identified:
+
+| Node | What it needs | Good for |
+| --- | --- | --- |
+| `SAM3Segment` | a text `prompt` (e.g. "the woman in the red coat") | Naming one subject in a scene that contains several |
+| `BiRefNetRMBG` | just `image` plus a `model` choice | Clean single-subject cutouts; `BiRefNet-matting` for hair and soft edges |
+| `LayerMask: BiRefNetUltraV2` (+ `LayerMask: LoadBiRefNetModelV2`) | a loaded `BIREFNET_MODEL` | The same family with explicit `detail_erode` / `detail_dilate` / black-and-white-point controls |
+| `SAM3Segmentation` (+ `LoadSAM3Model`) | point or box prompts | Precise manual control when a text prompt picks the wrong thing |
+| `RemoveBackground` (+ `LoadBackgroundRemovalModel`) | a loaded `BACKGROUND_REMOVAL` model | Core-node path, mask output only |
+
+`SAM3Segment` and `BiRefNetRMBG` are single self-contained nodes (no separate loader), so they are the cheapest place to start.
+
+Keep **two** versions of this mask:
+
+- the **tight** mask, for compositing the character back in Step 4;
+- a **grown** mask, for the inpaint in Step 3, so no rim of character pixels survives to be reconstructed into the background:
+
+```json
+{
+  "class_type": "GrowMask",
+  "inputs": { "mask": ["segmentation_node", 0], "expand": 12, "tapered_corners": true }
+}
+```
+
+## Step 3: Inpaint the hole with IPAdapter
+
+The grown mask leaves a character-shaped hole in the scene. Fill it by inpainting, with IPAdapter conditioning the fill on the original image so the reconstructed patch matches the scene's lighting, palette, and texture instead of inventing new content.
+
+Wire it as: checkpoint → IPAdapter → inpaint conditioning → sampler → decode.
+
+```json
+{
+  "ipadapter_loader": {
+    "class_type": "IPAdapterUnifiedLoader",
+    "inputs": { "model": ["checkpoint", 0], "preset": "PLUS (high strength)" }
+  },
+  "ipadapter": {
+    "class_type": "IPAdapterAdvanced",
+    "inputs": {
+      "model": ["ipadapter_loader", 0],
+      "ipadapter": ["ipadapter_loader", 1],
+      "image": ["original_image", 0],
+      "weight": 0.8,
+      "weight_type": "linear",
+      "combine_embeds": "concat",
+      "start_at": 0.0,
+      "end_at": 1.0,
+      "embeds_scaling": "V only",
+      "attn_mask": ["grow_mask", 0]
+    }
+  },
+  "inpaint_cond": {
+    "class_type": "InpaintModelConditioning",
+    "inputs": {
+      "positive": ["positive_prompt", 0],
+      "negative": ["negative_prompt", 0],
+      "vae": ["checkpoint", 2],
+      "pixels": ["original_image", 0],
+      "mask": ["grow_mask", 0],
+      "noise_mask": true
+    }
+  }
+}
+```
+
+Then run `KSampler` with `model` from the `IPAdapterAdvanced` output (not the raw checkpoint — that is what applies the IPAdapter conditioning) and `positive` / `negative` / `latent_image` from `inpaint_cond`'s three outputs, and decode with `VAEDecode`. `VAEEncodeForInpaint` is the alternative latent path if the checkpoint is not an inpainting model; it takes its own `grow_mask_by`, so you can skip the separate `GrowMask` on that branch.
+
+Two things to resolve at run time rather than assume: `IPAdapterUnifiedLoader` needs IPAdapter and CLIP-vision weights compatible with the checkpoint (use `search_models`, or wire `IPAdapterModelLoader` + `CLIPVisionLoader` explicitly via `IPAdapterAdvanced`'s `clip_vision` input), and the enum values above (`preset`, `weight_type`, `embeds_scaling`) should be confirmed with `get_node` before submitting.
+
+Prompt the inpaint for the background only — describe what should be behind the character, never the character.
+
+The output of this step is the reconstructed **background plate**: the same scene, no character, lighting and perspective intact.
+
+## Step 4: Recomposite the subject at a controllable opacity
+
+You now hold two aligned layers at the same resolution: the original image (character in place) and the background plate. Because the character was never moved, compositing needs no alignment work — the tight mask from Step 2 puts it back exactly where it was.
+
+Scale the mask to set opacity, then composite:
+
+```json
+{
+  "opacity": {
+    "class_type": "SolidMask",
+    "inputs": { "value": 0.45, "width": 1280, "height": 720 }
+  },
+  "faded_mask": {
+    "class_type": "MaskComposite",
+    "inputs": {
+      "destination": ["tight_mask", 0],
+      "source": ["opacity", 0],
+      "x": 0,
+      "y": 0,
+      "operation": "multiply"
+    }
+  },
+  "composite": {
+    "class_type": "ImageCompositeMasked",
+    "inputs": {
+      "destination": ["background_plate", 0],
+      "source": ["original_image", 0],
+      "x": 0,
+      "y": 0,
+      "resize_source": false,
+      "mask": ["faded_mask", 0]
+    }
+  }
+}
+```
+
+`ImageCompositeMasked` blends per pixel by mask value, so a mask multiplied down to `0.45` gives a 45% character over a 100% background — the background genuinely shows through, and `value` is a dial the user can move without regenerating anything. `SolidMask`'s `width`/`height` must match the image; run `FeatherMask` on the tight mask first if the edge reads as cut out.
+
+If a downstream step needs the character as a standalone RGBA layer instead of a flattened frame, use `JoinImageWithAlpha` (`image` = original image, `alpha` = faded mask).
+
+## Step 5: Hand the composite to the video model
+
+The composited frame is a normal image, so it feeds any image-conditioned video node — for the Seedance case, `ByteDance2ReferenceNode` (reference-to-video) or `ByteDance2FirstLastFrameNode` (first-frame). These gate their inputs behind a dynamic `model` combo, so call `get_node` for the exact slot names before wiring, and confirm the current class with `search_nodes` (`category: "partner/video"`).
+
+Save the background plate and the tight mask alongside the composite. Regenerating a different opacity, or re-cutting the composite for another shot, is then a Step 4 re-run rather than a full rebuild.
+
+## Key learnings:
+
+- **Prompting alone cannot control transparency** — models treat "semi-transparent" as a style hint, so opacity comes out inconsistent across seeds and unmovable after the fact. Hold the character and the background as separate layers and the opacity becomes a number you set.
+- **Generating the character separately from the background looks disconnected** — a character generated on its own and pasted over a separately generated scene reads as a sticker: the lighting direction, perspective, colour temperature, and grain never agree. Generate both together in one image first, then take them apart. That is the whole reason for Steps 1–3.
+- **Inpaint the hole, do not skip it** — the character is occluding scene content that has to exist before anything can show through it. Without the reconstruction pass there is nothing behind the character to reveal.
+- **Grow the mask for the inpaint, keep it tight for the composite** — one mask cannot do both jobs. A tight inpaint mask leaves a halo of character-coloured pixels that the fill then propagates outward; a grown composite mask eats the character's edges.
+- **The character never moves**, so the composite needs no alignment step — this is the practical payoff of generating together, on top of the visual coherence.


### PR DESCRIPTION
## ELI-5

Someone asked for a character you can see *through* — a ghost standing in a room, with the room visible behind them. Prompting for "semi-transparent" doesn't work: the model treats it as a vibe, and you get a different amount of see-through every seed with no way to adjust it afterwards. Generating the character on its own and pasting it over a background doesn't work either — the lighting and perspective never match, so it reads as a sticker.

The trick that does work: generate the character and the room together in one image (so they agree on lighting and perspective), cut the character out, use IPAdapter to paint the room back in behind where they were standing, then paste the character back on top at whatever opacity you like. Because you now hold two separate layers, opacity is just a number you set.

This PR writes that down as a second `technique-*` recipe.

## What this is

`skills/technique-transparent-subject-compositing.md` — a transcription of the pipeline reported as actually working, matching the structure and voice of the existing `skills/technique-combine-people.md`: one-line intent sentence, `## Step N` sections with concrete node names and JSON snippets, an options table, and a closing `## Key learnings`.

Doc-only, one new file, 151 lines. No server changes. Content reaches `comfy-cloud-mcp-server`'s `data/skills.json` on its own via the existing daily `refresh-skills.yml` auto-PR.

The `technique-` prefix is load-bearing and verified against the server's own filters: `mcp-clients.ts` `MANAGED_COMMAND_PREFIXES` copies it as a context file, `setup.ts:178`/`:614` keeps it out of the slash commands, and `prompts.ts` `isPromptSkill` (a `comfy-` prefix test) keeps it out of MCP prompt registration.

## Review requested from the technique's author and the creative team

**Please do not merge on bot review alone.** I could not resolve a GitHub handle for Sanghoon RHO among the visible Comfy-Org members, so I did not guess at a reviewer request — please add them (or the right creative-team reviewer) directly.

**Please do not merge on bot review alone.** This is domain content, and the reporter is the ground truth — Sanghoon RHO reported the working pipeline, and I transcribed it rather than deriving it. What I'd most like checked:

- Are Steps 1-4 the pipeline as actually run, in that order?
- Step 3 is the step with the most interpretation in it. The report says "use IPAdapter to inpaint the hole"; I wired that as `IPAdapterUnifiedLoader` -> `IPAdapterAdvanced` (with the grown mask as `attn_mask`) -> `InpaintModelConditioning` -> `KSampler`. If the actual graph differed, that section should be corrected to match.
- Suggested values (IPAdapter `weight: 0.8`, `preset: "PLUS (high strength)"`, `GrowMask expand: 12`, opacity `0.45`) are illustrative starting points, not reported measurements. Real numbers from the spike would be better.

## Verification

No test suite or linter in this repo, so verification is against the catalog and the consuming code:

- **Every node class named is verified present and non-deprecated** in `comfy-cloud-mcp-server`'s bundled `data/object_info.json.gz` — 30 classes. That snapshot is the cloud's own post-filtered catalog (`refresh-object-info.yml` sources it from `Comfy-Org/cloud@main:services/ingest/data/object_info.json`, already run through `cloud_disable_config.yaml`), so presence in it means cloud-available, not merely upstream-existent.
- **Deprecation was checked explicitly, not just existence** — prompted by #12, which is fixing exactly this class of rot in the sibling technique file. This recipe uses `GeminiNanoBanana2V2`, not the deprecated `GeminiNanoBanana2`.
- **All three JSON snippets** parse, and every input key is a real key for its `class_type`, with every enum literal (`preset`, `weight_type`, `combine_embeds`, `embeds_scaling`, `operation`) a real option for that input.
- **The two load-bearing mechanical claims were checked against ComfyUI source**, not asserted from memory: `composite()` in `comfy_extras/nodes_mask.py` is `mask*source + (1-mask)*destination`, a per-pixel linear blend with no binary clamp — which is the entire reason the opacity dial works; and `MaskComposite` multiply writes only the overlap region and does not resize, which is why an undersized `SolidMask` silently leaves the subject fully opaque. Both are now stated in the doc.
- `claude plugin validate ./claude-code` passes (untouched by this PR).

## Negative-claim falsification

The doc asserts a negative ("prompting alone cannot control transparency"), so I went looking for a path that would falsify it rather than only asserting it. Two turned up in the bundled catalog and templates:

- `LayeredDiffusionApply` / `LayeredDiffusionDecodeRGBA` (the Layer Diffuse family) — available on cloud, generates genuinely transparent RGBA natively.
- Template `video_wan2.1_alpha_t2v_14B` — "alpha channel support for transparent backgrounds and semi-transparent" video.

Neither solves the reported problem: both produce a subject on a transparent background (an alpha cutout with no scene), which is the "generated separately" failure mode this recipe exists to avoid — there is still nothing reconstructed behind the subject to show through. So the recipe stands, but I added an explicit fork at the top routing the alpha-cutout ask to Layer Diffuse and a `search_templates`-first instruction, rather than leaving a reader to infer that no native-transparency node exists. The doc redirects; it does not dead-end.

## Judgment calls

- **`skills/` is marked legacy in the README** ("frozen; will be removed once that installer fully retires"), but it remains the single source of truth that `refresh-skills.ts` mirrors into the server, and it is where the sibling technique file lives. Adding here per the ticket. Flagging in case the technique surface is meant to migrate to `claude-code/` — that would be a separate move for both technique files together, not this PR.
- **No slash command added** under `claude-code/commands/`. `technique-*` files are AI-context recipes, not user-invoked commands, so that is deliberate.
- **One follow-up this PR does not do:** `setup.ts:609` has a hardcoded `techniqueDescriptions` map listing only `technique-combine-people`, so `update skills` will list this file with an empty description until a one-line entry is added there. That is a server change and out of scope per the ticket; worth a follow-up in `comfy-cloud-mcp-server`.
- Suggested numeric values are illustrative — called out above and worth the reporter's correction.
