### PR TITLE
fix(generate-audio): recommend SaveAudioAdvanced over the deprecated SaveAudio

### DIFF
--- a/claude-code/commands/generate-audio.md
+++ b/claude-code/commands/generate-audio.md
@@ -16,7 +16,9 @@ Follow these steps exactly:
 
 4. **Validate the workflow has inputs and outputs before submitting.** Confirm the JSON contains:
    - At least one **input node** carrying the user's intent (text prompt node, LoadAudio for audio-to-audio, etc.).
-   - At least one **output/save node** wired to the final audio tensor (`SaveAudio` or the partner node's own save output).
+   - At least one **output/save node** wired to the final audio tensor (`SaveAudioAdvanced` or the partner node's own save output).
+
+   `SaveAudioAdvanced` (display name "Save Audio (Advanced)") is the current save node, and it requires `format` alongside `audio` and `filename_prefix` — the older `SaveAudio`, `SaveAudioMP3`, and `SaveAudioOpus` classes are marked deprecated in the node catalog and are hidden from `search_nodes`.
 
    API-backed partner nodes often produce an audio tensor but **do not include a save node by default** — you must add one and wire it to their output. Without it the job runs successfully but produces nothing retrievable, wasting compute. Do not skip this check.
 

--- a/skills/comfy-generate-audio.md
+++ b/skills/comfy-generate-audio.md
@@ -12,7 +12,9 @@ Follow these steps exactly:
 
 4. **Validate the workflow has inputs and outputs before submitting.** Confirm the JSON contains:
    - At least one **input node** carrying the user's intent (text prompt node, LoadAudio for audio-to-audio, etc.).
-   - At least one **output/save node** wired to the final audio tensor (`SaveAudio` or the partner node's own save output).
+   - At least one **output/save node** wired to the final audio tensor (`SaveAudioAdvanced` or the partner node's own save output).
+
+   `SaveAudioAdvanced` (display name "Save Audio (Advanced)") is the current save node, and it requires `format` alongside `audio` and `filename_prefix` — the older `SaveAudio`, `SaveAudioMP3`, and `SaveAudioOpus` classes are marked deprecated in the node catalog and are hidden from `search_nodes`.
 
    API-backed partner nodes often produce an audio tensor but **do not include a save node by default** — you must add one and wire it to their output. Without it the job runs successfully but produces nothing retrievable, wasting compute. Do not skip this check.
 


### PR DESCRIPTION
## ELI-5

The audio recipe told agents "save your audio with `SaveAudio`." That node is retired — Comfy Cloud's node search hides retired nodes, so an agent that followed the recipe and then searched for `SaveAudio` got nothing back. This points the recipe at the current node, `SaveAudioAdvanced`, and adds one line telling an agent that already knows the old names why they're gone.

## The problem

`skills/comfy-generate-audio.md` Step 4 instructed agents to wire the final audio tensor to `SaveAudio`. In the Comfy Cloud MCP server's bundled node catalog (`data/object_info.json.gz`), `SaveAudio`, `SaveAudioMP3` and `SaveAudioOpus` are all `deprecated: true` — their display names literally end in `(DEPRECATED)` — and `search_nodes` filters deprecated matches out of its results by default, returning them only as a "N deprecated match(es) hidden" note.

So the recipe sent agents to build with a class the same server's discovery surface then refuses to show. The workflows still *run* (deprecated nodes execute), so this is guidance quality rather than breakage — but this file is served live as the MCP `generate-audio` prompt, which makes the inconsistency agent-visible. Same defect class as #12 (`technique-combine-people`).

## What changed

Verified against the catalog blob on `comfy-cloud-mcp-server`'s default branch, not guessed:

| Class | Deprecated | Display name | Required inputs |
| :-- | :-- | :-- | :-- |
| `SaveAudio` | **true** | `Save Audio (FLAC) (DEPRECATED)` | `audio`, `filename_prefix` |
| `SaveAudioMP3` | **true** | `Save Audio (MP3) (DEPRECATED)` | `audio`, `filename_prefix`, `quality` |
| `SaveAudioOpus` | **true** | `Save Audio (Opus) (DEPRECATED)` | `audio`, `filename_prefix`, `quality` |
| `SaveAudioAdvanced` | false | `Save Audio (Advanced)` | `audio`, `filename_prefix`, `format` |

- **Step 4's save-node bullet now names `SaveAudioAdvanced`.** It is `output_node: true` and its required inputs are a strict superset of the old `SaveAudio`'s, so it is a drop-in for the recipe's purpose.
- **A redirect line follows the bullet list**, in the style of #12: it names the three old classes on a line that says they are deprecated, so an agent holding an old name is redirected rather than dead-ended.
- **The redirect line also names the `format` requirement.** This is the one addition beyond the literal ask (see judgment calls): `SaveAudioAdvanced` requires `format` where `SaveAudio` did not, so a naive swap that carried over only `audio` + `filename_prefix` would fail validation. It costs a clause and removes the footgun.

Nothing else in either file changed — Step 0's recent `api node/` rewording and every other step are untouched.

## Judgment calls

1. **The Claude Code slash command mirror is updated too, which the ticket did not ask for.** `claude-code/commands/generate-audio.md` is the same body plus a frontmatter block, shipped as the `/comfy-cloud:generate-audio` plugin command, and the two have been maintained in lockstep (the recent `partner/` → `api node/` edit landed in both). It carried the identical `SaveAudio` recommendation, and it is the copy Claude Code users actually invoke — fixing only the skill would have left the user-facing command stale. Flagged rather than done silently; easy to drop the second file if the split is intentional.
2. **The `format` clause**, above.

## Verification

No test or lint tooling exists in this repo (no `package.json`, no linter config; the only workflow is the unreviewed-merge detector), so verification is the recipe's own contract plus a local replica of the downstream gate.

- `grep -n 'SaveAudio' skills/comfy-generate-audio.md claude-code/commands/generate-audio.md` — the only bare `SaveAudio` occurrences left are `SaveAudioAdvanced`; the legacy names appear only on the line that says they are deprecated.
- **Downstream gate replica.** `comfy-cloud-mcp-server` gains a test that fails if any bundled skill body names a class the bundled `object_info` marks `deprecated: true`, exempting lines that contain the word "deprecated". I re-implemented that rule (same whole-word regex with `[A-Za-z0-9_]` lookarounds, same per-line exemption) and ran it over every file in `skills/` and `claude-code/commands/` against the 94 deprecated classes in the shipped catalog. **Both audio files: zero offenders.** The `SaveAudioAdvanced` recommendation is not a false pass — the lookahead means the `SaveAudio` pattern does not match inside `SaveAudioAdvanced`. The only remaining offenders repo-wide are `technique-combine-people` (skill and command), which is #12's scope, not this PR's — note that #12 does not currently update its own command mirror either.
- **Falsification of the deprecation claim.** The new line asserts three classes are retired and hidden, so the premise was checked empirically rather than taken from the ticket: the four `deprecated` / `display_name` / `output_node` / required-input values in the table above were read out of the catalog blob on the server's default branch, and the "hidden from `search_nodes`" half was confirmed in the server's discovery source, which filters deprecated matches out of results and returns them as a separate hidden-count note. The change redirects to a live class rather than dead-ending, so no capability is denied.
- Step 4 re-read end to end; it still parses as natural agent guidance.

## Downstream

`comfy-cloud-mcp-server` re-mirrors this file daily into its bundled `data/skills.json`. A companion ticket patches that snapshot directly so the live prompt is fixed without waiting on the auto-refresh, and retires the recorded stale-reference exemption that currently lets `comfy-generate-audio:SaveAudio` pass the gate.
