### PR TITLE
feat(comfy-build): scaffold the builder skill under comfy-cli/

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -24,8 +24,12 @@ jobs:
     env:
       DO_NOT_TRACK: "1"
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The job installs comfy-cli from PyPI, so it must not leave a usable
+          # GITHUB_TOKEN in the git config for that code to find.
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       # `skills validate` landed in 1.11.0.

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,41 @@
+# Checks every installer-consumed skill under comfy-cli/ against comfy-cli's own
+# skill contract. The contract lives in the CLI, not here: a mismatch between a
+# directory name and its `name:` frontmatter fails on the user's machine at
+# install time, which is far too late to find out.
+name: Validate Skills
+
+on:
+  pull_request:
+    paths:
+      - "comfy-cli/**"
+      - ".github/workflows/validate-skills.yml"
+  push:
+    branches: [main]
+    paths:
+      - "comfy-cli/**"
+      - ".github/workflows/validate-skills.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      DO_NOT_TRACK: "1"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      # `skills validate` landed in 1.11.0.
+      - run: pip install "comfy-cli>=1.11"
+      - name: Validate each skill directory
+        run: |
+          shopt -s nullglob
+          dirs=(comfy-cli/*/)
+          # An empty run would pass while proving nothing.
+          [[ ${#dirs[@]} -gt 0 ]] || { echo "no skill directories under comfy-cli/"; exit 1; }
+          for dir in "${dirs[@]}"; do
+            comfy skills validate "${dir%/}"
+          done

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Commands are namespaced under the plugin, e.g. `/comfy-cloud:generate-image`, `/
 
 - **`claude-code/`** — the `comfy-cloud` Claude Code plugin: `commands/` (the slash commands) plus `.claude-plugin/plugin.json` (metadata + the bundled MCP server). **Edit commands here.**
 - **`.claude-plugin/marketplace.json`** — the marketplace manifest so `/plugin marketplace add Comfy-Org/comfy-skills` resolves the plugin.
+- **`comfy-cli/`** — skills that [comfy-cli](https://github.com/Comfy-Org/comfy-cli)'s `comfy skills install` fetches from `main` and writes into Claude Code, Cursor and `AGENTS.md`. One directory per skill holding a single `SKILL.md` whose `name:` frontmatter equals the directory name; CI checks that with `comfy skills validate`.
 - **`skills/`** — *legacy* flat command files for the deprecated `comfy-cloud-mcp` curl installer. Frozen; will be removed once that installer fully retires.
 
 ## Authoring rule: steer the approach, defer the specifics

--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: comfy-build
+description: Build a ComfyUI distribution on the Comfy developer platform with comfy-cli — turn a local ComfyUI install, a workflow file, or a described intent into a distribution that builds, pin its dependencies before the first paid build, and read a failed build's log. Scaffold only; the guidance is not written yet.
+---
+
+# comfy-build
+
+Turning a starting point into a ComfyUI distribution that builds, driven entirely
+through `comfy distribution` in [comfy-cli](https://github.com/Comfy-Org/comfy-cli).
+
+## This skill is a scaffold
+
+**It carries no guidance yet.** The file exists so the installer has something to
+deliver and so a later revision reaches users without a CLI release. Everything
+below is what will fill it, not what it says today.
+
+**Until it is filled, do not improvise a build.** Read `comfy distribution --help`
+and the per-command `--help` for the real command surface, tell the user this
+skill is still a stub, and do not guess at a definition — cutting a version
+starts a build that costs the user money.
+
+## What will fill it
+
+- **The path**: the command sequence from each of the three starting points — a
+  local install, a workflow file, a described intent — and when to leave it.
+- **Platform facts an agent cannot infer**: what a distribution is, that a
+  version is immutable so a fix is always a new cut, and what a build costs in
+  time so the user hears expectations before paying.
+- **The pinning method**: how to anticipate a dependency conflict across
+  ComfyUI, every custom node and torch, before the first paid build.
+- **The limits of the free checks**: `validate` proves existence, not
+  resolution, so a passing validate is not a safe build.
+- **Failure reading**: how to map a failed target's build log to one definition
+  edit, one revision per failed cut.
+- **The restated guardrails**: what the platform website enforces at creation
+  time, restated so the CLI path refuses what the website would refuse.
+
+## For maintainers
+
+The design and the features that fill this file are in
+[Local agent access to the builder via comfy-cli skills](https://app.notion.com/p/3c26d73d365081ef9322ca2978e49d3d).
+
+`comfy skills install` fetches this file from `main` and writes it beside the
+skills comfy-cli bundles, so a merge here reaches users on their next install
+without waiting on a CLI release.
+The directory name and the `name:` above must stay identical — comfy-cli's
+installer rejects a mismatch, and it rejects it on the user's machine, not here.


### PR DESCRIPTION
## Why

`comfy skills install` is about to fetch a sixth skill from this repo, so that revising the builder skill's judgment never waits on a comfy-cli release. This PR is the container that fetch resolves to: valid to the installer's contract, and empty of the judgment the build features fill in.

Change: [\[comfy-skills\] The builder skill's scaffold and home](https://app.notion.com/p/3c26d73d3650819bb2d3c0e7da5ec925) · Feature: [the builder skill reaches the user's agent](https://app.notion.com/p/3c26d73d3650817cbd18f0e48f21ea8c) · Design: [Local agent access to the builder via comfy-cli skills](https://app.notion.com/p/3c26d73d365081ef9322ca2978e49d3d)

## What lands

- **`comfy-cli/comfy-build/SKILL.md`**: one directory, one file, `name:` frontmatter equal to the directory name. A signpost body saying what will fill it and telling an agent not to improvise a build in the meantime, since cutting a version costs the user money.
- **A new top-level `comfy-cli/` folder**: skills that comfy-cli's installer fetches, as a sibling of `openclaw/`, which already groups a directory-shaped skill by the host that consumes it.
- **`.github/workflows/validate-skills.yml`**: runs the CLI's own `comfy skills validate` over every directory under `comfy-cli/`. The contract lives in the CLI, not restated here.
- **README repo layout**: one bullet for `comfy-cli/`, since the layout list is the only place that says where a file belongs.

## Where this sits

```mermaid
flowchart LR
    REPO["comfy-skills · the builder skill's home ◀ this PR"]
    INST["comfy-cli · the skills installer"]
    DIRS["agent skill directories<br>Claude Code, Cursor, AGENTS.md"]
    FIVE["the five bundled skills"]
    REPO --> INST
    FIVE --> INST
    INST --> DIRS
    classDef out fill:#f5f5f5,stroke:#bbbbbb,stroke-dasharray:4 3,color:#888888;
    classDef feat fill:#ffe08a,stroke:#b8860b,color:#000;
    classDef task fill:#ffe08a,stroke:#1a7f37,stroke-width:4px,color:#000;
    class FIVE,INST,DIRS out
    class REPO task
```

## Validation

**Local stack, end to end**: comfy-cli 1.16-equivalent from source (`comfy_cli` at `0a6cb6e`), against this working tree:

- `comfy skills validate comfy-cli/comfy-build` → `{"valid": true, "name": "comfy-build", "bundled": false}`.
- `comfy skills install --scope project --skill <abs path>/comfy-cli/comfy-build` → `wrote` for all three targets: `.claude/skills/comfy-build/SKILL.md`, `.cursor/rules/comfy-build.mdc`, and a `<!-- comfy-build:start -->` fence in `AGENTS.md`.

**Not run**: the new CI workflow itself, which first executes on this PR, and anything involving a remote fetch, which is the [comfy-cli change](https://app.notion.com/p/3c26d73d365081ba9cefc5fb4cd0c2ab)'s job.

## Departures from the plan

<details>
<summary>Three, all declared</summary>

- **Path moved from `skills/` to `comfy-cli/`.** The plan said `skills/comfy-build/SKILL.md` and called it "first of its kind in the repo". Both are wrong against the repo as it stands: this README documents `skills/` as legacy and frozen pending removal with the `comfy-cloud-mcp` curl installer, and `openclaw/comfy/SKILL.md` is already a directory-shaped skill carrying `name:`/`description:` frontmatter that passes the CLI's contract today.
- **No named release.** The plan's deliverable included a tag for the fetch to pin. James chose to pin to `main` instead, so no tag is cut here and the CLI resolves `main` on every install.
- **CI validate added.** The plan left this to the task's judgement. Added, because the rule most likely to be got wrong, directory name equals frontmatter `name:`, otherwise fails on a user's machine at install time rather than on the PR that broke it.

</details>

