### PR TITLE
feat(comfy-build): write the first-shot content for a local install

### DIFF
--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -34,7 +34,7 @@ Versions move. Read them at run time, and never carry one in from memory.
 | Question | Command |
 | --- | --- |
 | What Python, CUDA and torch will the build run? | `comfy distribution base-images` |
-| Which os/gpu targets can be cut? | `comfy distribution build-targets` |
+| Which os/gpu targets exist? | `comfy distribution build-targets` |
 | Which folders may a model go in? | `comfy distribution model-dirs` |
 | What did this version actually seal? | `comfy distribution version manifest <version-id>` |
 | Can I reach the builder? | `comfy distribution list` |
@@ -125,8 +125,8 @@ Both real policies share one shape: `{"mode": "blocklist", "list": []}` permits 
 The cut happens inside `--execute` and is not revisable: a fix is always a new version. So state it in one short block, then create:
 
 - **What is going in:** the ComfyUI pin, the base image with the Python and CUDA it brings, how many packs and how each is sourced, how many models and whether they upload or download.
-- **What is permitted:** the model, partner-node and custom-node postures in plain words, including the ones defaulting to allow-all.
-- **What it costs:** the default cut builds `linux/nvidia` only. A green build takes roughly ten minutes, a dependency failure usually surfaces in one or two, and the build sandbox is cut off after two hours.
+- **What is permitted:** the model and partner-node postures in plain words, including that both default to allow-all when nothing is set.
+- **What it costs:** a cut from the CLI builds `linux/nvidia`, the default, and takes no target flag, so do not promise a Windows or CPU artifact from here. A green build takes roughly ten minutes, a dependency failure usually surfaces in one or two, and the build sandbox is cut off after two hours.
 - **That it is one-way:** every correction is a new cut.
 
 ## Reading the verdict

--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: comfy-build
-description: Build a ComfyUI distribution on the Comfy developer platform with comfy-cli — turn a working local ComfyUI install into a distribution that builds in the cloud, pin its dependencies before the first paid build, and read the build's verdict. Use when someone asks to deploy, package, or cloud-run their install.
+description: Build a ComfyUI distribution on the Comfy developer platform with comfy-cli. Turn a working local ComfyUI install into a distribution that builds in the cloud, pin its dependencies before the first paid build, and read the build's verdict. Use when someone asks to deploy, package, or cloud-run their install.
 ---
 
 # comfy-build
 
-There is a platform. A user asking to run their ComfyUI "in the cloud" is asking for a **distribution**, which the Comfy platform builds for them — not for a Dockerfile you write yourself. Nothing inside a ComfyUI install points at the platform, so this is the one thing you cannot discover from the working directory.
+There is a platform. A user asking to run their ComfyUI "in the cloud" is asking for a **distribution**, which the Comfy platform builds for them, not for a Dockerfile you write yourself. Nothing inside a ComfyUI install points at the platform, so this is the one thing you cannot discover from the working directory.
 
 The whole surface is `comfy distribution` in [comfy-cli](https://github.com/Comfy-Org/comfy-cli). Start with `comfy distribution --help`; every step below names the command that does it.
 
-**Covered here: a working local install.** A user holding only a workflow file, or only a description of what they want, is not covered yet — say so rather than improvising one.
+**Covered here: a working local install.** A user holding only a workflow file, or only a description of what they want, is not covered yet, so say so rather than improvising one.
 
 ## The path
 
@@ -17,7 +17,7 @@ The whole surface is `comfy distribution` in [comfy-cli](https://github.com/Comf
 
 | Step | Command | What it is for |
 | --- | --- | --- |
-| Define | `comfy distribution scan --python <comfyui-python> -o definition.json` | Evidence about the install. Not a buildable definition — see below. |
+| Define | `comfy distribution scan --python <comfyui-python> -o definition.json` | Evidence about the install. Not a buildable definition; see below. |
 | Define | `comfy distribution resolve <filename> …` | Which local models have a hash-matched public download, so they need no upload. `--execute` runs this itself; use it early to know what the upload will weigh. |
 | Check | `comfy distribution create --from definition.json --name <name>` (no `--execute`) | Offline preview of exactly what would be sent. Makes no network call. |
 | Create | `comfy distribution create --from definition.json --name <name> --execute` | **Creates the distribution and immediately cuts build 1.** |
@@ -49,7 +49,7 @@ Versions move. Read them at run time, and never carry one in from memory.
 
 `scan` reports each pack as `source: git` (a checkout with an origin and a HEAD) or `source: local`. **`--execute` refuses to upload a local node**, and `comfy node install` writes archives rather than clones, so on an install built with the comfy CLI every pack scans as local and the default path dead-ends.
 
-Do not go hunting for a git tag — a registry version is a package semver and often has no tag at all. Each installed pack's `pyproject.toml` carries the two fields the builder wants:
+Do not go hunting for a git tag. A registry version is a package semver and often has no tag at all. Each installed pack's `pyproject.toml` carries the two fields the builder wants:
 
 ```toml
 name = "comfyui-kjnodes"     # the registry node id
@@ -80,15 +80,15 @@ git ls-remote --tags https://github.com/comfyanonymous/ComfyUI.git v0.30.2
 
 ### Pins: the freeze is evidence, and the target is not this machine
 
-`scan`'s `pipDependencies` is a `pip freeze` of the install, tagged in its header with the platform it came from. It describes the machine the workflow ran on. The build runs somewhere else — `comfy distribution base-images` says where.
+`scan`'s `pipDependencies` is a `pip freeze` of the install, tagged in its header with the platform it came from. It describes the machine the workflow ran on. The build runs somewhere else, and `comfy distribution base-images` says where.
 
 - **Torch, torchvision and torchaudio: pin all three or none.** The builder installs that stack itself, freezes it, and holds every other install to those exact versions. Pinning any one of the three **replaces** the builder's line and **releases the other two**, so a lone `torch==` pin is how a mismatched torchvision arrives transitively and the build dies with `torchvision::nms does not exist`. Dropping all three is the safe default; keeping all three means matching what `comfy distribution base-images` reports.
 - **Never use a local version tag** (`+cu130`, `+cpu`). The linux/nvidia resolve runs against PyPI alone, where such a version does not exist, so the pin that looks most correct is the one that fails.
 - **Pin what actually conflicts, and nothing else.** `pipDependencies` is applied as an override, which forces a version rather than adding a package: pinning something nothing else requires installs nothing.
-- **A bare name is not a pin.** `torch` without a version, or a pin carrying an environment marker, is ignored rather than honoured — write an exact `==` or leave it out.
+- **A bare name is not a pin.** `torch` without a version, or a pin carrying an environment marker, is ignored rather than honoured. Write an exact `==`, or leave it out.
 - **Option lines are dropped** from `pipDependencies`, so `--index-url` and friends cannot redirect the resolve. Do not try.
 
-Prove the set resolves before spending a build — against PyPI alone and the base image's Python, which is what the builder does:
+Prove the set resolves before spending a build, against PyPI alone and the base image's Python, which is what the builder does:
 
 ```
 uv pip compile pins.txt --python-version <base image python> --python-platform x86_64-unknown-linux-gnu
@@ -103,11 +103,11 @@ A freeze can be unbuildable because the install itself is inconsistent: `comfy n
 Two ways to read it wrong:
 
 - **`ok: true` is not "it will build".** The local resolve above is the primary check; `validate` is a second net.
-- **The CLI prints "Definition resolves." and then the JSON.** Read the JSON. `warnings[]` carries definite ref misses — an unresolvable `baseComfyVersion` or node ref appears there while `ok` stays `true`.
+- **The CLI prints "Definition resolves." and then the JSON.** Read the JSON. `warnings[]` carries definite ref misses: an unresolvable `baseComfyVersion` or node ref appears there while `ok` stays `true`.
 
 ## What the website sets that this path does not
 
-A distribution created through the website's wizard always carries the fields below. A definition authored here carries only what is put in it, and **nothing errors when a policy is missing — the version simply seals as allow-all.** Set each one, or say its default out loud before creating.
+A distribution created through the website's wizard always carries the fields below. A definition authored here carries only what is put in it, and **nothing errors when a policy is missing. The version simply seals as allow-all.** Set each one, or say its default out loud before creating.
 
 | Field | The wizard's rule | Here |
 | --- | --- | --- |
@@ -122,7 +122,7 @@ Both real policies share one shape: `{"mode": "blocklist", "list": []}` permits 
 
 ## Before creating, say this
 
-The cut happens inside `--execute` and is not revisable — a fix is always a new version. So state it in one short block, then create:
+The cut happens inside `--execute` and is not revisable: a fix is always a new version. So state it in one short block, then create:
 
 - **What is going in:** the ComfyUI pin, the base image with the Python and CUDA it brings, how many packs and how each is sourced, how many models and whether they upload or download.
 - **What is permitted:** the model, partner-node and custom-node postures in plain words, including the ones defaulting to allow-all.
@@ -136,7 +136,7 @@ The cut happens inside `--execute` and is not revisable — a fix is always a ne
 | What the failure says | What it means |
 | --- | --- |
 | `freeze: pin ComfyUI "...": ref not found in remote advertisement` | The ComfyUI pin is not a real git ref. Prefix the tag. |
-| `assemble: ComfyUI did not start` | Something was installed against a torch the runtime does not have — usually one torch-stack member pinned while the other two were released. |
+| `assemble: ComfyUI did not start` | Something was installed against a torch the runtime does not have, usually one torch-stack member pinned while the other two were released. |
 | `no version of ... your requirements are unsatisfiable` | A pin PyPI cannot serve, usually a local version tag. |
 
 ## For maintainers
@@ -147,5 +147,5 @@ The design and the features that fill this file are in
 `comfy skills install` fetches this file from `main` and writes it beside the
 skills comfy-cli bundles, so a merge here reaches users on their next install
 without waiting on a CLI release.
-The directory name and the `name:` above must stay identical — comfy-cli's
+The directory name and the `name:` above must stay identical, because comfy-cli's
 installer rejects a mismatch, and it rejects it on the user's machine, not here.

--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -18,7 +18,7 @@ The whole surface is `comfy distribution` in [comfy-cli](https://github.com/Comf
 | Step | Command | What it is for |
 | --- | --- | --- |
 | Define | `comfy distribution scan --python <comfyui-python> -o definition.json` | Evidence about the install. Not a buildable definition — see below. |
-| Define | `comfy distribution resolve` | Finds public download URLs for local model files, so they need no upload. |
+| Define | `comfy distribution resolve <filename> …` | Which local models have a hash-matched public download, so they need no upload. `--execute` runs this itself; use it early to know what the upload will weigh. |
 | Check | `comfy distribution create --from definition.json --name <name>` (no `--execute`) | Offline preview of exactly what would be sent. Makes no network call. |
 | Create | `comfy distribution create --from definition.json --name <name> --execute` | **Creates the distribution and immediately cuts build 1.** |
 | Read | `comfy distribution version get <version-id>` | `status`, `artifactCounts`, and a `failureReason` per target. |

--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -1,39 +1,143 @@
 ---
 name: comfy-build
-description: Build a ComfyUI distribution on the Comfy developer platform with comfy-cli — turn a local ComfyUI install, a workflow file, or a described intent into a distribution that builds, pin its dependencies before the first paid build, and read a failed build's log. Scaffold only; the guidance is not written yet.
+description: Build a ComfyUI distribution on the Comfy developer platform with comfy-cli — turn a working local ComfyUI install into a distribution that builds in the cloud, pin its dependencies before the first paid build, and read the build's verdict. Use when someone asks to deploy, package, or cloud-run their install.
 ---
 
 # comfy-build
 
-Turning a starting point into a ComfyUI distribution that builds, driven entirely
-through `comfy distribution` in [comfy-cli](https://github.com/Comfy-Org/comfy-cli).
+There is a platform. A user asking to run their ComfyUI "in the cloud" is asking for a **distribution**, which the Comfy platform builds for them — not for a Dockerfile you write yourself. Nothing inside a ComfyUI install points at the platform, so this is the one thing you cannot discover from the working directory.
 
-## This skill is a scaffold
+The whole surface is `comfy distribution` in [comfy-cli](https://github.com/Comfy-Org/comfy-cli). Start with `comfy distribution --help`; every step below names the command that does it.
 
-**It carries no guidance yet.** The file exists so the installer has something to
-deliver and so a later revision reaches users without a CLI release. Everything
-below is what will fill it, not what it says today.
+**Covered here: a working local install.** A user holding only a workflow file, or only a description of what they want, is not covered yet — say so rather than improvising one.
 
-**Until it is filled, do not improvise a build.** Read `comfy distribution --help`
-and the per-command `--help` for the real command surface, tell the user this
-skill is still a stub, and do not guess at a definition — cutting a version
-starts a build that costs the user money.
+## The path
 
-## What will fill it
+**Define, check locally, create, read.** In that order, and the third step is the one that costs something.
 
-- **The path**: the command sequence from each of the three starting points — a
-  local install, a workflow file, a described intent — and when to leave it.
-- **Platform facts an agent cannot infer**: what a distribution is, that a
-  version is immutable so a fix is always a new cut, and what a build costs in
-  time so the user hears expectations before paying.
-- **The pinning method**: how to anticipate a dependency conflict across
-  ComfyUI, every custom node and torch, before the first paid build.
-- **The limits of the free checks**: `validate` proves existence, not
-  resolution, so a passing validate is not a safe build.
-- **Failure reading**: how to map a failed target's build log to one definition
-  edit, one revision per failed cut.
-- **The restated guardrails**: what the platform website enforces at creation
-  time, restated so the CLI path refuses what the website would refuse.
+| Step | Command | What it is for |
+| --- | --- | --- |
+| Define | `comfy distribution scan --python <comfyui-python> -o definition.json` | Evidence about the install. Not a buildable definition — see below. |
+| Define | `comfy distribution resolve` | Finds public download URLs for local model files, so they need no upload. |
+| Check | `comfy distribution create --from definition.json --name <name>` (no `--execute`) | Offline preview of exactly what would be sent. Makes no network call. |
+| Create | `comfy distribution create --from definition.json --name <name> --execute` | **Creates the distribution and immediately cuts build 1.** |
+| Read | `comfy distribution version get <version-id>` | `status`, `artifactCounts`, and a `failureReason` per target. |
+| Read | `comfy distribution version logs <version-id>` | The build log for one target. |
+| Revise | `comfy distribution update <id> --from definition.json`, then `comfy distribution validate <id>`, then `comfy distribution version create <id>` | The only way to change anything. Every cut is a new version. |
+
+**There is no create-without-building.** `--execute` creates *and* cuts, so the free server-side `validate` cannot run before the first build. Everything checkable for free, check before `--execute`; `validate` is the gate on every cut after that.
+
+## Ask the platform, never remember
+
+Versions move. Read them at run time, and never carry one in from memory.
+
+| Question | Command |
+| --- | --- |
+| What Python, CUDA and torch will the build run? | `comfy distribution base-images` |
+| Which os/gpu targets can be cut? | `comfy distribution build-targets` |
+| Which folders may a model go in? | `comfy distribution model-dirs` |
+| What did this version actually seal? | `comfy distribution version manifest <version-id>` |
+| Can I reach the builder? | `comfy distribution list` |
+
+`comfy cloud whoami` reports only the OAuth session and names a production URL. It says `signed_in: false` while a `COMFY_BUILDER_TOKEN` in the environment is working perfectly. **It is not the answer to "can I build".** `comfy distribution list` returning a list is.
+
+## Authoring the definition
+
+`scan` writes evidence, not something you can build. Three of its fields need judgment before anything is sent.
+
+### Custom nodes: prefer the registry pin
+
+`scan` reports each pack as `source: git` (a checkout with an origin and a HEAD) or `source: local`. **`--execute` refuses to upload a local node**, and `comfy node install` writes archives rather than clones, so on an install built with the comfy CLI every pack scans as local and the default path dead-ends.
+
+Do not go hunting for a git tag — a registry version is a package semver and often has no tag at all. Each installed pack's `pyproject.toml` carries the two fields the builder wants:
+
+```toml
+name = "comfyui-kjnodes"     # the registry node id
+version = "1.4.9"            # the registry version
+```
+
+which becomes:
+
+```json
+{ "id": "comfyui-kjnodes", "name": "comfyui-kjnodes", "registryVersion": "1.4.9" }
+```
+
+The builder resolves that pair against the registry and installs the published artifact. A node sets **exactly one** source:
+
+- `repository` (an `https://github.com/{org}/{repo}` URL), optionally with a `gitRef`,
+- `registryVersion` plus `id`, or
+- `blobId`, for something genuinely private.
+
+Two nodes resolving to the same `custom_nodes/` directory are rejected at the boundary, case-insensitively.
+
+### The ComfyUI pin: prefix it and prove it
+
+`scan` writes `baseComfyVersion` from the install's version marker, which is bare (`0.30.2`). The builder resolves that field as a **git ref**, and ComfyUI tags releases with a `v`. **An unedited scan definition fails its first build for this reason alone.** Set the tag, and confirm it exists before spending a build:
+
+```
+git ls-remote --tags https://github.com/comfyanonymous/ComfyUI.git v0.30.2
+```
+
+### Pins: the freeze is evidence, and the target is not this machine
+
+`scan`'s `pipDependencies` is a `pip freeze` of the install, tagged in its header with the platform it came from. It describes the machine the workflow ran on. The build runs somewhere else — `comfy distribution base-images` says where.
+
+- **Torch, torchvision and torchaudio: pin all three or none.** The builder installs that stack itself, freezes it, and holds every other install to those exact versions. Pinning any one of the three **replaces** the builder's line and **releases the other two**, so a lone `torch==` pin is how a mismatched torchvision arrives transitively and the build dies with `torchvision::nms does not exist`. Dropping all three is the safe default; keeping all three means matching what `comfy distribution base-images` reports.
+- **Never use a local version tag** (`+cu130`, `+cpu`). The linux/nvidia resolve runs against PyPI alone, where such a version does not exist, so the pin that looks most correct is the one that fails.
+- **Pin what actually conflicts, and nothing else.** `pipDependencies` is applied as an override, which forces a version rather than adding a package: pinning something nothing else requires installs nothing.
+- **A bare name is not a pin.** `torch` without a version, or a pin carrying an environment marker, is ignored rather than honoured — write an exact `==` or leave it out.
+- **Option lines are dropped** from `pipDependencies`, so `--index-url` and friends cannot redirect the resolve. Do not try.
+
+Prove the set resolves before spending a build — against PyPI alone and the base image's Python, which is what the builder does:
+
+```
+uv pip compile pins.txt --python-version <base image python> --python-platform x86_64-unknown-linux-gnu
+```
+
+A freeze can be unbuildable because the install itself is inconsistent: `comfy node install` can leave an environment that already fails `pip check`. Run it. A conflict there is a conflict about to be shipped.
+
+## What `validate` proves, and what it does not
+
+`comfy distribution validate <id>` is free, and worth running before every cut after the first. It checks the definition's **shape**, that a ComfyUI version is pinned, and that each pinned pip package and version **exists**. It does not resolve the set together, so it returns `ok: true` on definitions that die at assemble.
+
+Two ways to read it wrong:
+
+- **`ok: true` is not "it will build".** The local resolve above is the primary check; `validate` is a second net.
+- **The CLI prints "Definition resolves." and then the JSON.** Read the JSON. `warnings[]` carries definite ref misses — an unresolvable `baseComfyVersion` or node ref appears there while `ok` stays `true`.
+
+## What the website sets that this path does not
+
+A distribution created through the website's wizard always carries the fields below. A definition authored here carries only what is put in it, and **nothing errors when a policy is missing — the version simply seals as allow-all.** Set each one, or say its default out loud before creating.
+
+| Field | The wizard's rule | Here |
+| --- | --- | --- |
+| `baseComfyVersion` | Refuses to create without one; never defaults to a branch. | Required for a cut too. Set the `v`-prefixed tag. |
+| `baseImage` | Always written; the catalog's default when unpicked. | Omitted means whatever the catalog defaults to at cut time, which moves. Set it from `comfy distribution base-images`. |
+| `modelPolicy` | Always written. Allow-all is a blocklist naming nothing. | Absent means allow-all, sealed into the version's manifest. |
+| `partnerNodePolicy` | Always written, same encoding. | Absent means every partner node is permitted. |
+| `customNodePolicy` | Always written. | The website records it; no service reads it today. Do not describe it to the user as an enforced restriction. |
+| name | Defaults to "New Build". | `--name` defaults to `untitled-distribution`. Ask. |
+
+Both real policies share one shape: `{"mode": "blocklist", "list": []}` permits everything, and `{"mode": "allowlist", "list": [...]}` permits only what it names.
+
+## Before creating, say this
+
+The cut happens inside `--execute` and is not revisable — a fix is always a new version. So state it in one short block, then create:
+
+- **What is going in:** the ComfyUI pin, the base image with the Python and CUDA it brings, how many packs and how each is sourced, how many models and whether they upload or download.
+- **What is permitted:** the model, partner-node and custom-node postures in plain words, including the ones defaulting to allow-all.
+- **What it costs:** the default cut builds `linux/nvidia` only. A green build takes roughly ten minutes, a dependency failure usually surfaces in one or two, and the build sandbox is cut off after two hours.
+- **That it is one-way:** every correction is a new cut.
+
+## Reading the verdict
+
+`comfy distribution version get` reports `artifactCounts` and, on a failed artifact, a `failureReason`; `comfy distribution version logs` gives that target's log. Three failures only a build surfaces, each pointing back at a rule above:
+
+| What the failure says | What it means |
+| --- | --- |
+| `freeze: pin ComfyUI "...": ref not found in remote advertisement` | The ComfyUI pin is not a real git ref. Prefix the tag. |
+| `assemble: ComfyUI did not start` | Something was installed against a torch the runtime does not have — usually one torch-stack member pinned while the other two were released. |
+| `no version of ... your requirements are unsatisfiable` | A pin PyPI cannot serve, usually a local version tag. |
 
 ## For maintainers
 

--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -19,13 +19,17 @@ The whole surface is `comfy distribution` in [comfy-cli](https://github.com/Comf
 | --- | --- | --- |
 | Define | `comfy distribution scan --python <comfyui-python> -o definition.json` | Evidence about the install. Not a buildable definition; see below. |
 | Define | `comfy distribution resolve <filename> …` | Which local models have a hash-matched public download, so they need no upload. `--execute` runs this itself; use it early to know what the upload will weigh. |
-| Check | `comfy distribution create --from definition.json --name <name>` (no `--execute`) | Offline preview of exactly what would be sent. Makes no network call. |
-| Create | `comfy distribution create --from definition.json --name <name> --execute` | **Creates the distribution and immediately cuts build 1.** |
+| Check | `comfy distribution create --from definition.json --name <name>` (no `--execute`) | Offline preview. Makes no network call, and shows you what `create` would strip. |
+| Seed | `comfy distribution create --from seed.json --name <name> --execute` | Creates the distribution. Also cuts a throwaway build. See below. |
+| Load | `comfy distribution update <id> --from definition.json` | Puts the real definition on it. This, not `create`, is what carries it. |
+| Check | `comfy distribution validate <id>` | Free. Run it before every cut. |
+| Cut | `comfy distribution version create <id>` | The build that counts. |
 | Read | `comfy distribution version get <version-id>` | `status`, `artifactCounts`, and a `failureReason` per target. |
 | Read | `comfy distribution version logs <version-id>` | The build log for one target. |
-| Revise | `comfy distribution update <id> --from definition.json`, then `comfy distribution validate <id>`, then `comfy distribution version create <id>` | The only way to change anything. Every cut is a new version. |
 
-**There is no create-without-building.** `--execute` creates *and* cuts, so the free server-side `validate` cannot run before the first build. Everything checkable for free, check before `--execute`; `validate` is the gate on every cut after that.
+**`create` does not send your definition; it sends a reduction of it.** It keeps `baseComfyVersion` and `pipDependencies`, drops `baseImage`, `modelPolicy` and `partnerNodePolicy` on the floor, and turns every node that is not a git checkout into an upload that `--execute` then refuses outright. A registry-pinned definition cannot go through it at all.
+
+So seed with a definition small enough not to care about, then `update` with the real one. Two consequences to say out loud: **the first create spends a throwaway build**, because `--execute` always cuts and there is no create-without-building; and **from the second cut onward `validate` is a real gate**, which is the only free server-side check you get.
 
 ## Ask the platform, never remember
 
@@ -62,6 +66,12 @@ which becomes:
 { "id": "comfyui-kjnodes", "name": "comfyui-kjnodes", "registryVersion": "1.4.9" }
 ```
 
+**Confirm the id before you trust it.** A pack published from a pull-request preview carries that preview's id in its `pyproject.toml` (`pr-was-node-suite-comfyui-47064894`), which does not exist in the registry. Check each one, and fall back to the directory name, which is what the registry usually knows it as:
+
+```
+curl -s -o /dev/null -w '%{http_code}' "https://api.comfy.org/nodes/<id>/install?version=<version>"
+```
+
 The builder resolves that pair against the registry and installs the published artifact. A node sets **exactly one** source:
 
 - `repository` (an `https://github.com/{org}/{repo}` URL), optionally with a `gitRef`,
@@ -96,6 +106,15 @@ uv pip compile pins.txt --python-version <base image python> --python-platform x
 
 A freeze can be unbuildable because the install itself is inconsistent: `comfy node install` can leave an environment that already fails `pip check`. Run it. A conflict there is a conflict about to be shipped.
 
+### The resolve is not the final environment
+
+**A clean `uv pip compile` does not mean the packs will import.** Two things happen after the resolve that it cannot see: ComfyUI-Manager runs each pack's own install step at build time, which `uv pip install`s packages outside the lock, and a wheel compiled against NumPy 1.x aborts at import under NumPy 2.x however cleanly it resolved. That is a C-API break, invisible to a resolver, and it fails at `assemble` with `numpy.core.multiarray failed to import`.
+
+So pin the two axes that float, even when nothing looks like it conflicts:
+
+- **`numpy`**, because unpinned it resolves to the newest 2.x while older packs still ship 1.x-compiled binaries. Match what the install actually runs.
+- **`opencv-python` and `opencv-python-headless` together**, because they collide on `cv2` and packs pull both. An install carrying both locally will carry both into the build.
+
 ## What `validate` proves, and what it does not
 
 `comfy distribution validate <id>` is free, and worth running before every cut after the first. It checks the definition's **shape**, that a ComfyUI version is pinned, and that each pinned pip package and version **exists**. It does not resolve the set together, so it returns `ok: true` on definitions that die at assemble.
@@ -126,7 +145,7 @@ The cut happens inside `--execute` and is not revisable: a fix is always a new v
 
 - **What is going in:** the ComfyUI pin, the base image with the Python and CUDA it brings, how many packs and how each is sourced, how many models and whether they upload or download.
 - **What is permitted:** the model and partner-node postures in plain words, including that both default to allow-all when nothing is set.
-- **What it costs:** a cut from the CLI builds `linux/nvidia`, the default, and takes no target flag, so do not promise a Windows or CPU artifact from here. A green build takes roughly ten minutes, a dependency failure usually surfaces in one or two, and the build sandbox is cut off after two hours.
+- **What it costs:** two builds, since the seeding create spends one. A cut from the CLI builds `linux/nvidia`, the default, and takes no target flag, so do not promise a Windows or CPU artifact from here. A green build takes roughly ten minutes, a dependency failure usually surfaces in one or two, and the build sandbox is cut off after two hours.
 - **That it is one-way:** every correction is a new cut.
 
 ## Reading the verdict
@@ -136,7 +155,8 @@ The cut happens inside `--execute` and is not revisable: a fix is always a new v
 | What the failure says | What it means |
 | --- | --- |
 | `freeze: pin ComfyUI "...": ref not found in remote advertisement` | The ComfyUI pin is not a real git ref. Prefix the tag. |
-| `assemble: ComfyUI did not start` | Something was installed against a torch the runtime does not have, usually one torch-stack member pinned while the other two were released. |
+| `assemble: ComfyUI did not start` + `numpy.core.multiarray failed to import` | A pack's binary was compiled against NumPy 1.x and the resolve floated NumPy to 2.x. Pin `numpy`. |
+| `assemble: ComfyUI did not start`, torch or `torchvision::nms` in the log | Something was installed against a torch the runtime does not have, usually one torch-stack member pinned while the other two were released. |
 | `no version of ... your requirements are unsatisfiable` | A pin PyPI cannot serve, usually a local version tag. |
 
 ## For maintainers


### PR DESCRIPTION
Fills the [builder skill scaffold](https://github.com/Comfy-Org/comfy-skills/pull/21) with the path from a scanned local ComfyUI install to a green build. **Why:** a bare agent pointed at this problem does not find the platform at all, and when it does, four of its eleven recorded stalls each cost a paid build to discover. Every one of those is a definition edit it could have made for free had it known.

**Sub-issue:** [\[comfy-skills\] Write the first-shot content](https://app.notion.com/p/3c26d73d36508165905ac953464ce8f7) · **Feature:** [a local install becomes a distribution that builds](https://app.notion.com/p/3c26d73d365081fd8353d532eb56ca00) · **Depends on:** #21 (base branch; merge that first)

Also carries the sibling sub-issue [Restate the website's creation guardrails](https://app.notion.com/p/3c26d73d365081868d03d45323962dae): both are prose in this one file and their tickets say they land in one tag move.

- **The path, and where the free checks actually sit:** `--execute` creates *and* cuts, so the server-side `validate` cannot run before the first build. Everything checkable for free is checked locally first; `validate` gates every cut after that.
- **Custom nodes go in by registry pin:** `comfy node install` writes archives rather than clones, so every pack scans as `source: local` and `--execute` refuses to upload one. Each pack's `pyproject.toml` already carries the registry id and version the builder resolves, so no git archaeology is needed.
- **Torch, torchvision and torchaudio are pinned all together or not at all:** pinning one replaces the builder's frozen stack line and *releases* the other two, which is how a mismatched torchvision arrives transitively.
- **The guardrails the website sets and this path does not:** `baseImage`, `modelPolicy` and `partnerNodePolicy` are always written by the wizard; absent here they seal as allow-all and nothing errors. The skill sets them or says the default out loud before the cut.

Facts that move (Python, CUDA, torch, targets, model folders) are read from the CLI at run time and never written into the file.

## Where this sits

```mermaid
flowchart LR
    subgraph SKILL["the builder skill · comfy-skills"]
        SCAF["scaffold and home<br>#21"]
        FIRST["first-shot content<br>◀ this PR"]
    end
    AGENT["terminal agent"]
    CLI["comfy-cli · comfy distribution"]
    B["comfy-builder"]
    WEB["platform website · bypassed"]
    SCAF --> FIRST
    FIRST --> AGENT
    AGENT --> CLI
    CLI --> B
    WEB -.-> B
```

## Validation

- **Unit tests · not run.** This repo has none; the change is one prose file.
- **Local stack, end to end · not run, and out of scope here.** Driving a real install to a green build is [its own sub-issue](https://app.notion.com/p/3c26d73d3650817e814cc764e829b2a4) and is not yet done, so nothing below claims the skill has produced a build.
- **The installer contract · passed.** `comfy skills validate comfy-cli/comfy-build` returns `valid: true`, and a path install writes the skill to all three surfaces (`.claude/skills/comfy-build/SKILL.md`, `.cursor/rules/comfy-build.mdc`, `AGENTS.md`) with its tables intact. This is what #21's CI job runs.
- **The registry claim · proved against the live registry.** All six packs from the recorded session resolve at the exact endpoint the builder's freeze calls, keyed on their `pyproject.toml` name and version:

  ```
  comfyui-kjnodes 1.4.9               -> 200 https://cdn.comfy.org/kijai/comfyui-kjnodes/1.4.9/node.zip
  comfyui-art-venture 1.1.7           -> 200 https://cdn.comfy.org/protogaia/comfyui-art-venture/1.1.7/node.zip
  comfyui-inpaint-cropandstitch 3.0.12 -> 200 …
  comfyui-inpaint-nodes 1.4.3         -> 200 …
  comfyui_fill-nodes 2.26.0           -> 200 …
  was-node-suite-comfyui 1.0.1        -> 200 …
  ```

- **Every claim about the platform · read out of the code**, not the transcript: the definition schema and its validation, the freeze's registry and git paths, the torch-stack constraint and its release rule, the default cut target, the sandbox timeout, and the wizard's create path.

<details>
<summary><b>Each recorded stall, and the line that prevents it</b></summary>

| # | The stall | The line |
|---|---|---|
| 1 | Never found the platform; wrote a Dockerfile | Opening paragraph |
| 2 | `--execute` cannot upload a local custom node | Custom nodes: prefer the registry pin |
| 3 | Nothing maps a registry version to a git ref | Same section, with the `pyproject.toml` recipe |
| 4 | `scan` writes a bare ComfyUI version the builder cannot resolve | The ComfyUI pin: prefix it and prove it |
| 5 | `scan` freezes the host platform, never the target | The freeze is evidence, and the target is not this machine |
| 6 | Dropping a pin is as dangerous as keeping a wrong one | Pin all three torch-stack members or none |
| 7 | The builder resolves against PyPI only | Never use a local version tag; the `uv pip compile` check |
| 8 | `validate` passing means less than its name | What `validate` proves, and what it does not |
| 9 | The frozen install already failed `pip check` | Run `pip check` before cutting |
| 10 | The published schema is too loose to author against | The exactly-one-source rule and the policy shapes |
| 11 | `comfy cloud whoami` says signed out while builds work | Ask the platform, never remember |

</details>

## Departures from the plan

- **Home:** the sub-issue says `skills/comfy-build/SKILL.md`; the file is at `comfy-cli/comfy-build/SKILL.md`, the path #21 decided, because `skills/` is documented as legacy and frozen.
- **Scope:** the sibling guardrails sub-issue is in this PR rather than its own, since both are sections of this one file.
- **`customNodePolicy`:** the wizard writes it but no service reads it, so the skill says exactly that rather than restating it as an enforced rule.
