### PR TITLE
docs: mention Cursor in plugin and marketplace descriptions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "comfy-skills",
-  "description": "Comfy skills and plugins for AI coding agents. Includes comfy-cloud, the Comfy Cloud MCP connection plus slash commands for Claude Code.",
+  "description": "Comfy skills and plugins for AI coding agents. Includes comfy-cloud, the Comfy Cloud MCP connection plus slash commands for Claude Code and Cursor.",
   "owner": {
     "name": "Comfy Org",
     "url": "https://comfy.org"
@@ -9,7 +9,7 @@
     {
       "name": "comfy-cloud",
       "source": "./claude-code",
-      "description": "Comfy Cloud in Claude Code: the hosted MCP connection plus slash commands for generating images, video, audio, and 3D and searching the catalog.",
+      "description": "Comfy Cloud in Claude Code and Cursor: the hosted MCP connection plus slash commands for generating images, video, audio, and 3D and searching the catalog.",
       "homepage": "https://docs.comfy.org/cloud/mcp"
     }
   ]

--- a/claude-code/.claude-plugin/plugin.json
+++ b/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "comfy-cloud",
-  "description": "Comfy Cloud for Claude Code — generate images, video, audio, and 3D, search models, nodes, and templates, and run ComfyUI workflows. Bundles the hosted Comfy Cloud MCP connection plus slash commands.",
+  "description": "Comfy Cloud for Claude Code and Cursor — generate images, video, audio, and 3D, search models, nodes, and templates, and run ComfyUI workflows. Bundles the hosted Comfy Cloud MCP connection plus slash commands.",
   "version": "0.1.0",
   "author": {
     "name": "Comfy Org",


### PR DESCRIPTION
The marketplace and plugin description fields only mention Claude Code, but this plugin also installs and renders in Cursor (which reads the same `.claude-plugin/marketplace.json` and `plugin.json` manifests). This updates the three description fields to say "Claude Code and Cursor" so the plugin renders accurately in Cursor's plugin UI without changing anything for Claude Code users.

No functional changes — description strings only.

Made with [Cursor](https://cursor.com)