### PR TITLE
Add Cursor plugin manifest

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "comfy-skills",
+  "owner": {
+    "name": "Comfy Org"
+  },
+  "metadata": {
+    "description": "Comfy skills and plugins for AI coding agents. Includes comfy-cloud, the Comfy Cloud MCP connection plus slash commands for Cursor."
+  },
+  "plugins": [
+    {
+      "name": "comfy-cloud",
+      "source": ".",
+      "description": "Generate images, video, audio, and 3D, search models, nodes, and templates, and run ComfyUI workflows from Cursor.",
+      "homepage": "https://docs.comfy.org/cloud/mcp"
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "comfy-cloud",
+  "description": "Generate images, video, audio, and 3D, search models, nodes, and templates, and run ComfyUI workflows from Cursor.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Comfy Org"
+  },
+  "homepage": "https://docs.comfy.org/cloud/mcp",
+  "logo": "https://raw.githubusercontent.com/Comfy-Org/comfy-skills/main/assets/logo.png",
+  "commands": "claude-code/commands"
+}

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "comfy-cloud": {
+      "url": "https://cloud.comfy.org/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Adds a Cursor plugin at the repo root so that comfy-cloud can be installed and rendered natively in Cursor.

Made with [Cursor](https://cursor.com)