### PR TITLE
fix(comfy-build): what four end-to-end runs found, including a core-class trap

### DIFF
--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -11,7 +11,9 @@ The platform commands here are the `comfy build` group, from
 
 **Needs comfy-cli 1.18.0 or newer.** Earlier versions have no `build` group at
 all, so `comfy build scan` answers `No such command 'build'`. Check with
-`comfy --version`, and `pip install -U comfy-cli` if it is older.
+`comfy build --help`: a CLI without the group has no `build` command at all,
+and a CLI run from source reports a version no comparison can use. Upgrade with
+`pip install -U comfy-cli`.
 
 **A cut is not undoable and a build takes minutes**, so the user hears what is
 about to be sent, and agrees, before anything is created on the platform.
@@ -92,16 +94,17 @@ comfy --json build from-workflow --from <workflow>.json --name <name>
   from source reports a version no comparison can use. When the verb is there
   and the call still fails, fall back to assembling the set as *When all you
   have is a description* describes.
-- **It creates on the platform, so get the yes first.** There is no preview to
-  run and no `--execute` to withhold: the call itself writes the build. Say what
-  it will create, and wait.
+- **Importing is the only way to see what the workflow means, and it writes a
+  build.** There is no preview verb and no `--execute` to withhold, so you
+  cannot describe the contents before creating the record. Ask for the import on
+  those terms: it creates a build, cuts nothing and spends nothing, and the
+  decision that costs anything comes after you both read the report.
 - **Hand it the file unchanged.** It reads the editing format and the API
   export, so converting first only refuses files it would have taken.
 - **Save the report before you touch the definition.** Everything below lives in
   `report`, and the build's copy of it is cleared by the first save, so an
   update run first destroys it with no way back but a fresh import. Take the
-  `--json` output to a file and work from that. Pretty mode prints a summary
-  only, capped at eight names per line.
+  `--json` output to a file and work from that.
 - **It creates but does not cut, and cannot be cut until `baseComfyVersion` is
   set.** A workflow names no ComfyUI version, so a fresh import always comes
   back with `comfyVersionRequired: true`. Add one, then cut:
@@ -113,6 +116,10 @@ comfy --json build from-workflow --from <workflow>.json --name <name>
   ```
 
   `--json` is a root flag, so it goes before `build`, not after `get`.
+- **An empty `definition` is a real answer, not a failure.** A graph of core
+  classes needs no pack, so `{}` plus a `baseComfyVersion` is a legitimate cut.
+  Add the models the report named before you cut it, or you ship an environment
+  that runs the graph and cannot load its weights.
 - **No model the workflow names reaches the definition**, because a workflow
   gives a filename and no source. Each one comes back under `models` with a
   `status`: `matched` means the catalog holds that exact name, `suggested`
@@ -549,10 +556,14 @@ Say all of this, in plain words, and wait for a yes:
 
 From a workflow, five more:
 
-- **`unresolvedClasses`**: node classes nothing installable provides. The graph
-  will not run without them, so this is the list to take to the user.
-  `unknownClasses` is the same thing with the packs their nearest matches belong
-  to.
+- **`unresolvedClasses` stops the run.** Nothing installable provides these
+  classes, so no build of any shape makes the graph run. Take the list to the
+  user and ask what those nodes are, rather than cutting an environment that
+  cannot do the thing they asked for. A private or in-development node has
+  answers: a `repository` pin, or `blob upload` as a node zip.
+  `unknownClasses` is the same list as objects, each carrying a pack for its
+  nearest known class name when one scored well enough, and `classType` alone
+  when none did.
 - **`uncheckedClasses`**: the registry never answered, so these packs are not in
   the definition and nothing established whether they exist. Cutting now ships
   an environment without them.

--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -56,7 +56,8 @@ comfy build release get <release-id>
 - **`comfy which` names the install** when the user has not said where it is.
 - **`--name` is yours to choose and the user's to keep.** It is how they will
   find the build later, so propose one from the install or the result they asked
-  for and say it in the disclosure. Omitted, every build is `untitled-build`.
+  for and say it in the disclosure. `create` defaults it to `untitled-build`;
+  `from-workflow` requires it.
 - **`create` without `--execute` is the preview.** It makes no network call and
   prints the exact definition that would be sent plus the upload total. Always
   run it, and show the user that total before the line that sends it.
@@ -111,9 +112,15 @@ comfy --json build from-workflow --from <workflow>.json --name <name>
 
   ```shell
   comfy --json build get <build-id> | jq .data.definition > def.json
+  # add baseComfyVersion, and the models below, to def.json
   comfy build update <build-id> --from def.json
+  comfy build validate <build-id>
   comfy build release create <build-id>
   ```
+
+  **The version alone is not enough to cut something that works.** Add the
+  models in the same edit, or the cut goes green and the graph cannot load its
+  weights. `validate` is the only free check on this path, so run it.
 
   `--json` is a root flag, so it goes before `build`, not after `get`.
 - **An empty `definition` is a real answer, not a failure.** A graph of core
@@ -124,15 +131,18 @@ comfy --json build from-workflow --from <workflow>.json --name <name>
   gives a filename and no source. Each one comes back under `models` with a
   `status`: `matched` means the catalog holds that exact name, `suggested`
   carries near-miss names to check before trusting one, and `missing` is yours
-  to find. All three still need `comfy build resolve` for a `sourceUri` and a
-  digest, which the report never carries. `usedBy` names the classes that loaded
+  to find. All three still need `comfy build resolve` for a `sourceUri`, which
+  the report never carries. Take its `sha256` too when a candidate has one; the
+  entry may go without, and that is an unpinned fetch to say out loud rather
+  than a digest to invent. `usedBy` names the classes that loaded
   it, which is the lead worth following for its `type`: `directories` answers
   where the catalog keeps a file of that name, not where the pack reads, and it
   is absent on everything except `matched`.
 - **`pinnedToLatest: true` means at least one pack** was pinned to the
   registry's newest published version, since a workflow names none. Importing
   the same file next week can then build something else, and that is worth
-  saying out loud.
+  saying out loud. `false` on a graph of core classes means no pack was pinned
+  because none was needed.
 - **A pack under `packsWithoutVersion` arrives with no `gitRef`**, so it builds
   from whatever its default branch points at that day. Pin a commit before you
   cut, exactly as *Confirm, then write the definition* requires of any
@@ -554,7 +564,8 @@ Say all of this, in plain words, and wait for a yes:
   works.
 - **`unverifiedPins`**: the registry never answered, so nothing was checked.
 
-From a workflow, five more:
+From a workflow, five more. **An advisory with nothing to say is absent, not
+empty**, so a missing key is the all-clear and there is no `[]` to find:
 
 - **`unresolvedClasses` stops the run.** Nothing installable provides these
   classes, so no build of any shape makes the graph run. Take the list to the

--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -155,8 +155,9 @@ The user names a result they want and owns no ComfyUI install, so `scan` and
 above arrives at the same place, one step ahead: it names its node classes
 exactly, so start from those rather than from search terms. You assemble
 the candidate set yourself, then write the definition by hand. When `comfy which`
-still names a path, say so and let the user settle it: a `workspace_type` of
-`recent` is a remembered directory rather than a declared workspace.
+still names a path, say so and let the user settle it before going further: a
+`workspace_type` of `recent` is a remembered directory rather than a declared
+workspace, and whether it is theirs decides which path you are on.
 
 **Create nothing until the user confirms that set.** No build is created, no
 release is cut and no blob is uploaded until the user has seen the whole set and
@@ -196,14 +197,16 @@ curl -s "https://api.comfy.org/nodes/search?search=background+removal"
   whose table is titled "List of All Nodes".
 - **No tag or category search exists**, so description text is the only topic
   surface a search can aim at.
-- **Ask which pack publishes a node class**, which is the whole route when a
-  workflow named the classes exactly:
+- **Settle core before you ask the registry**, against the ComfyUI ref you are
+  about to pin. A class upstream ships needs nothing in `customNodes`, whatever
+  the registry says about it. Then, for the rest:
   `curl -s -w '\nHTTP %{http_code}\n' "https://api.comfy.org/comfy-nodes/<ClassName>/node"`.
-  A 404 means core
-  or unknown, never missing, and those two need telling apart before you answer:
-  a class upstream ComfyUI ships needs nothing in `customNodes`, while one
-  nothing ships is a graph that will not run. Check the class against the
-  ComfyUI ref you are about to pin, and say which of the two you concluded.
+- **A 200 names a pack claiming that class, not the pack that provides it.**
+  Anyone may publish a node under a core name, and `LoadImage` answers 200 with
+  an unrelated prompt pack behind 64,000 downloads. Taking that answer installs
+  something the user never asked for to supply a node they already have, and the
+  build goes green. A 404 means core or unknown, never missing, and a class
+  nothing ships is a graph that will not run. Say which you concluded.
 
 ### Check the models
 
@@ -270,7 +273,8 @@ starts cold, inside that first run. Declaring what it wants is what stops that,
 so read the pack for the file it looks for and the directory it looks in, and
 declare exactly those. **Declare all of them or none:** a pack that checks for
 four files and finds three fetches all four again, so a partial declaration buys
-nothing. When you cannot name the whole set, keep the pack and say the first run
+nothing. A `models` entry carries a weight, so a set holding a `.json` or a
+`.py` cannot be completed at all and is a none. When you cannot name the whole set, keep the pack and say the first run
 will be slow.
 
 ### Confirm, then write the definition
@@ -379,8 +383,8 @@ node_zip` and give the node that `blobId`.
 **A scanned registry id is the pack's claim about itself.** `[project] name` is
 whatever the pack wrote, so a fork or a PR build carries a name nothing
 publishes: one real install read `pr-was-node-suite-comfyui-47064894` for
-`was-node-suite-comfyui`. `--execute` refuses on that, but only the check tells
-you what to write instead:
+`was-node-suite-comfyui`. `--execute` refuses on that, so check every scanned id
+before you cut rather than buying the refusal:
 
 ```shell
 curl -s "https://api.comfy.org/nodes/search?search=<id>"
@@ -403,7 +407,8 @@ alone, a freeze taken on macOS with Python 3.13 forces those exact versions onto
 a linux Python 3.12 build. That is not a subtle risk; it is the usual reason a
 first build fails.
 
-**So cut the first build with `pipDependencies` emptied.** The build resolves the
+**So cut the first build with `pipDependencies` emptied**, meaning the key
+carries an empty string or is left out; both read the same. The build resolves the
 packs' own requirements against the base image's torch, which is what you want.
 
 **Empty is the default, not a rule that outranks what you can already see.** The
@@ -531,7 +536,9 @@ Say all of this, in plain words, and wait for a yes:
   asks the builder for public candidates and rewrites a local entry into a fetch
   when a candidate's sha256 matches the file on disk. Three promised uploads can
   report `uploaded: 0`. Only the digest decides and the builder re-verifies it,
-  so it is safe, but a user who agreed to send files is owed the sentence. Offer
+  so it is safe, but a user who agreed to send files is owed the sentence. Where
+  every model already carries a `sourceUri` nothing is uploaded at all: say so,
+  and name what the builder fetches instead. Offer
   to list the filenames first.
 - **What it takes**: any upload, then a build of several minutes.
 - **What a failure means**: a fix and another build, and that you stop after
@@ -584,6 +591,11 @@ empty**, so a missing key is the all-clear and there is no `[]` to find:
   packs that claim one folder.
 - **`partnerClasses`**: nothing to install. The workflow calls a partner
   provider, so it needs partner access rather than a pack.
+
+**These are fields on an import's report, not on a cut.** `create --execute`
+answers with the ids and `uploaded` alone, and says `pythonSatisfied` and the
+policy warning in English on the way past. Their absence from a cut is not an
+all-clear, and no field anywhere says whether the registry pin check ran.
 
 Advisory values are echoed source text, not suggestions. A name in one of these
 lists is whatever the definition or a pack put there, up to and including

--- a/comfy-cli/comfy-build/SKILL.md
+++ b/comfy-cli/comfy-build/SKILL.md
@@ -390,10 +390,11 @@ before you cut rather than buying the refusal:
 curl -s "https://api.comfy.org/nodes/search?search=<id>"
 ```
 
-`total: 0` means nothing publishes it. Search the pack's real name, and read
-the whole page rather than the first row: a real search for `comfyui_fill-nodes`
-returns two, and one for the WAS suite returns three, including a different
-publisher's fork with more downloads. Take the slug and `latest_version.version`
+`total: 0` means nothing publishes it. Search the pack's real name as words
+rather than as a slug, since the endpoint matches a run of characters: `was
+node suite` returns three rows including a different publisher's fork with more
+downloads, while the exact slug returns one. Read the whole page rather than the
+first row. Take the slug and `latest_version.version`
 only from a row whose `repository` is the pack you scanned. When two rows could
 both be it, that choice is the user's. Correcting a wrong id, and
 removing a `local` pack, are the two edits to a source you may make; leave the


### PR DESCRIPTION
**TL;DR:** Correct the comfy-build skill against four end-to-end runs on staging, one of which showed the file sending an agent to install an unrelated pack to supply a core node.

Linear: [BE-8426](https://linear.app/comfyorg/issue/BE-8426)

**Why:** the skill had never been driven to a real build by anyone but its author. Four agents given only the file, and authorised to cut, produced three green builds and one correct refusal, and eighteen defects on the way.

**Validation**
* **Local stack, end to end**: three green builds on staging, each on the first cut, one per path. Scan: release `5fb7b0bd`, `deployable: true`, 15m36s. Workflow: release `c9a2fd84`, 12m29s. Described intent: release `ebb23011`, 13m51s. Each was driven by an agent reading only this file.
* **Local stack, end to end**: a workflow carrying a class nobody publishes. The agent refused to cut and spent nothing, which is the correct outcome and the case [BE-8426](https://linear.app/comfyorg/issue/BE-8426) names.
* **Not run**: Unit and Integration. This repository has no test suite and a skill file has nothing to execute.
* **Not run**: production. Every cut was staging, with `COMFY_BUILDER_URL` set on every call.

**What changed**
* **[comfy-skills] comfy-build/SKILL.md, Find the packs**: core is settled before the registry is asked, and a `200` from the class lookup is described as a claim rather than an answer. `LoadImage` returns one.
* **[comfy-skills] comfy-build/SKILL.md, the workflow shortcut**: the commands now write the models in and run `validate`, the report is saved before the first save clears it, `unresolvedClasses` stops the run, and an empty definition is named as a real answer.
* **[comfy-skills] comfy-build/SKILL.md, Reading what comes back and the disclosure**: the advisories are marked as an import's fields rather than a cut's, an absent key is the all-clear, and a build that uploads nothing has wording for it.

**Contradicts:** nothing. Two lines of the file disagreed with each other on whether to check `comfy --version` or check for the verb, and the version one is removed rather than kept.
